### PR TITLE
Feature/v2/exception test

### DIFF
--- a/src/main/java/com/Kkrap/Exception/SpecificNotFoundException.java
+++ b/src/main/java/com/Kkrap/Exception/SpecificNotFoundException.java
@@ -4,8 +4,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 @ResponseStatus(HttpStatus.NOT_FOUND) // 404 Not Found 상태 코드 반환
-public class FoldersNotFoundException extends RuntimeException {
-    public FoldersNotFoundException(String message) {
+public class SpecificNotFoundException extends RuntimeException {
+    public SpecificNotFoundException(String message) {
         super(message);
     }
 }

--- a/src/main/java/com/Kkrap/Handler/ErrorResponse.java
+++ b/src/main/java/com/Kkrap/Handler/ErrorResponse.java
@@ -1,0 +1,9 @@
+package com.Kkrap.Handler;
+
+public record ErrorResponse (
+        String message
+){
+    public static ErrorResponse from(String message) {
+        return new ErrorResponse(message);
+    }
+}

--- a/src/main/java/com/Kkrap/Handler/MasterExceptionHandler.java
+++ b/src/main/java/com/Kkrap/Handler/MasterExceptionHandler.java
@@ -1,0 +1,15 @@
+package com.Kkrap.Handler;
+
+import com.Kkrap.Exception.SpecificNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class MasterExceptionHandler {
+    @ExceptionHandler(SpecificNotFoundException.class)
+    public ResponseEntity<ErrorResponse> notFoundException(SpecificNotFoundException exception) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ErrorResponse.from(exception.getMessage()));
+    }
+}

--- a/src/main/java/com/Kkrap/Handler/ObjectStatusHandler.java
+++ b/src/main/java/com/Kkrap/Handler/ObjectStatusHandler.java
@@ -1,0 +1,15 @@
+package com.Kkrap.Handler;
+
+import com.Kkrap.Exception.SpecificNotFoundException;
+
+import java.util.Optional;
+
+public class ObjectStatusHandler {
+
+    public static void objectStatusHandler(Optional<Object> object, String message) {
+        if (object.isEmpty()){
+            throw new SpecificNotFoundException(message);
+        }
+    }
+
+}

--- a/src/test/java/com/Kkrap/Exception/ExceptionTest.java
+++ b/src/test/java/com/Kkrap/Exception/ExceptionTest.java
@@ -1,0 +1,45 @@
+package com.Kkrap.Exception;
+
+
+
+import com.Kkrap.Fixture.Users;
+import com.Kkrap.Handler.ObjectStatusHandler;
+import com.Kkrap.Repository.UsersRepository;
+import com.Kkrap.Service.LinksService;
+import org.apache.catalina.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest(classes = {ObjectStatusHandler.class})
+public class ExceptionTest {
+
+
+
+    @Test
+    @DisplayName("예외 발생으로 반환값이 제대로 동작하는지 테스트")
+    void SpecificNotFoundException_을_반환한다 () {
+
+        assertThrows(SpecificNotFoundException.class, () -> {
+            throw new SpecificNotFoundException("특정 행동에 대한 결과를 찾을 수 없음");
+        });
+
+    }
+
+    @Test
+    @DisplayName("공통된 객체가 비었으면 예외가 발생하고, 404 응답을 반환하는지 테스트")
+    void 예외응답핸들러_테스트() {
+        Users users = new Users(1L, "hello");
+
+
+        assertThrows(SpecificNotFoundException.class, () -> {
+            ObjectStatusHandler.objectStatusHandler(Optional.of(users), "사용자를 찾을 수 없음");
+        });
+
+    }
+}

--- a/src/test/java/com/Kkrap/Fixture/Users.java
+++ b/src/test/java/com/Kkrap/Fixture/Users.java
@@ -1,0 +1,11 @@
+package com.Kkrap.Fixture;
+
+public class Users {
+    private Long id;
+    private String name;
+
+    public Users(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+}


### PR DESCRIPTION
Not FOUND Http 응답 반환에서 사용할, 공통 예외처리 메소드를 구성하여 테스트를 진행

**문제**

Optional User 는 Null 을 체킹되면 상위 예외인 NullPointerException이 먼저 발생할 수 있음.

**추후 예정**

추후, Exception 구조를 다시 변경해야함

---

**해결하지 못한 것**

예외응답핸들러 테스트를 통과하지 못함

**사유**

원하는 테스트 결과를 반환할 given이 주어지지 않았음.
Optional로 인해 Null을 포함한 Users객체를 생성할 수 없는 상황