### PR TITLE
refactor: token 값이 전달되지 않은 예외, token 값이 존재할 때에 발생하는 핸들링 메서드 분리, 테스트 검증

### DIFF
--- a/src/main/java/com/Kkrap/Controller/AuthController.java
+++ b/src/main/java/com/Kkrap/Controller/AuthController.java
@@ -1,6 +1,7 @@
 package com.Kkrap.Controller;
 
 import com.Kkrap.RequestDTO.KaKaoTokenRequest;
+import com.Kkrap.ResponseDto.UsersProfileResponse;
 import com.Kkrap.Service.AuthService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -13,12 +14,16 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/auth")
 public class AuthController {
 
-    @Autowired
-    AuthService authService;
+    private final AuthService authService;
+
+    public AuthController(AuthService authService) {
+        this.authService = authService;
+    }
 
     //토큰 관리 방식
     @PostMapping("/kakao-login")
-    public ResponseEntity<?> kakaoLogin(@RequestBody KaKaoTokenRequest request){
-        return authService.kakaoLogin(request);
+    public ResponseEntity<UsersProfileResponse> kakaoLogin(@RequestBody KaKaoTokenRequest request){
+        var response = authService.kakaoLogin(request);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/Kkrap/Exception/ErrorCode.java
+++ b/src/main/java/com/Kkrap/Exception/ErrorCode.java
@@ -10,7 +10,8 @@ public enum ErrorCode {
 //    FOLDERS_NOT_FOUND(404, "FOLDERS-ERR-404", "존재하지 않는 폴더입니다.");
 
     USER_NOT_FOUND(404,"USERS-ERR-404","USERS NOT FOUND"),
-    FOLDERS_NOT_FOUND(404, "FOLDERS-ERR-404", "FOLDERS NOT FOUND");
+    FOLDERS_NOT_FOUND(404, "FOLDERS-ERR-404", "FOLDERS NOT FOUND"),
+    TOKEN_NOT_VALID(404, "TOKEN_NOT_VALID", "TOKEN NOT VALID");
 
     private int code;
     private String errorCode;

--- a/src/main/java/com/Kkrap/Exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/Kkrap/Exception/GlobalExceptionHandler.java
@@ -29,5 +29,11 @@ public class GlobalExceptionHandler {
 
     }
 
+    @ExceptionHandler(NotValidTokenException.class)
+    public ResponseEntity<ErrorResponse> notValidTokenException(NotValidTokenException ex) {
+        ErrorResponse response = ErrorResponse.from(ex.getErrorCode());
+        return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
+    }
+
 
 }

--- a/src/main/java/com/Kkrap/Exception/NotValidTokenException.java
+++ b/src/main/java/com/Kkrap/Exception/NotValidTokenException.java
@@ -1,0 +1,14 @@
+package com.Kkrap.Exception;
+
+import lombok.Getter;
+
+@Getter
+public class NotValidTokenException extends RuntimeException{
+
+    private ErrorCode errorCode;
+
+    public NotValidTokenException(String message, ErrorCode errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/Kkrap/Service/AuthService.java
+++ b/src/main/java/com/Kkrap/Service/AuthService.java
@@ -1,6 +1,8 @@
 package com.Kkrap.Service;
 
 import com.Kkrap.Entity.Users;
+import com.Kkrap.Exception.ErrorCode;
+import com.Kkrap.Exception.NotValidTokenException;
 import com.Kkrap.Repository.FoldersRepository;
 import com.Kkrap.Repository.UsersRepository;
 import com.Kkrap.RequestDTO.FoldersCreateRequest;
@@ -31,14 +33,18 @@ public class AuthService {
     @Autowired
     FoldersService foldersService;
 
-    @Autowired
-    FoldersRepository foldersRepository;
-    public ResponseEntity<?> kakaoLogin(@RequestBody KaKaoTokenRequest request){
+    public boolean isAccessToken(String token) {
+        if(token.equals("")){
+            throw new NotValidTokenException("토큰이 없습니다.", ErrorCode.TOKEN_NOT_VALID);
+        }
+        return false;
+    }
+
+    public UsersProfileResponse kakaoLogin(@RequestBody KaKaoTokenRequest request){
         String accessToken = request.getAccesstoken();
 
         if (accessToken.isEmpty()){
-            return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                    .body(new MessageResponse(404, "토큰 없음"));
+            isAccessToken(accessToken);
         }
 
         //1. 카카오 유저 정보 요청
@@ -72,13 +78,13 @@ public class AuthService {
             FoldersCreateRequest foldersCreateRequest = FoldersCreateRequest.of(newUser.getUserId(), "모든 링크", "모든 링크가 저장된 폴더입니다.", false);
             foldersService.save(foldersCreateRequest, newUser);
             UsersProfileResponse usersProfileResponse = UsersProfileResponse.of(newUser.getUserId(), newUser.getEmail(), newUser.getNickname(), newUser.getProfile(), newUser.getKakaoId());
-            return ResponseEntity.ok(usersProfileResponse);
+            return usersProfileResponse;
         }
         else
         {
             Users existingUser = CheckUser.get();
             UsersProfileResponse usersProfileResponse = UsersProfileResponse.of(existingUser.getUserId(), existingUser.getEmail(), existingUser.getNickname(), existingUser.getProfile(), existingUser.getKakaoId());
-            return ResponseEntity.ok(usersProfileResponse);
+            return usersProfileResponse;
         }
     }
 

--- a/src/test/java/com/Kkrap/Auth/AuthControllerTest.java
+++ b/src/test/java/com/Kkrap/Auth/AuthControllerTest.java
@@ -1,0 +1,44 @@
+package com.Kkrap.Auth;
+
+import com.Kkrap.RequestDTO.KaKaoTokenRequest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@AutoConfigureMockMvc
+@SpringBootTest
+@Transactional
+public class AuthControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+
+    @Autowired private ObjectMapper objectMapper;
+
+    @Test
+    void accessToken_is_empty() throws Exception {
+        String accessToken = "";
+        KaKaoTokenRequest request = new KaKaoTokenRequest(accessToken);
+        String content =  objectMapper.writeValueAsString(request);
+
+        MvcResult result = mockMvc.perform(post("/api/auth/kakao-login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(content)
+        ).andExpect(status().is4xxClientError()).andReturn();
+
+        assertThat(result).isNotNull();
+
+    }
+
+    // 카카오 유저 정보 요청
+
+}

--- a/src/test/java/com/Kkrap/Auth/AuthServiceTest.java
+++ b/src/test/java/com/Kkrap/Auth/AuthServiceTest.java
@@ -1,0 +1,40 @@
+package com.Kkrap.Auth;
+
+import com.Kkrap.Exception.NotValidTokenException;
+import com.Kkrap.RequestDTO.KaKaoTokenRequest;
+import com.Kkrap.Service.AuthService;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+public class AuthServiceTest {
+
+    @Autowired AuthService authService;
+
+
+    // 연동 로그인 종류에 맞춰서 확장성을 고려한 추상화가 필요할 수 있음
+
+    @Test
+    void isAccessToken() {
+        String id = "hello123";
+        String emptyToken = "";
+        String validToken = Base64.getEncoder().encodeToString(id.getBytes());
+        System.out.println(validToken);
+
+        assertThrows(NotValidTokenException.class, () -> {
+            authService.isAccessToken(emptyToken);
+        });
+
+        var result = authService.isAccessToken(validToken);
+
+        Assertions.assertThat(result).isNotNull();
+        Assertions.assertThat(result).isEqualTo(false);
+    }
+
+}


### PR DESCRIPTION
#### 변경사항

- AccessToken 핸들링 메서드로 분리
- kakaoLogin 메서드 반환타입 dto로 변경
- authController 에서 ResponseEntity를 생성하여 반환하도록 변경

#### 변경예정

- 카카오 유저 정보 요청 로직을 전략 구조로 변경 예정
  - 기능 단위로 분리
  - 추가 클래스가 생성될수도 있음
  - AuthService 가 가지고 있는 카카오 로그인에 관한 정보는 '카카오 로그인에 대한 정보를 제공하는 클래스'로 분리가 필요하다고 판단하였음
  - 유저 정보 검색 후 처음 로그인한 사용자 핸들링 로직 메서드로 분리 예정

#### 참고

로직 구조 변경에 모든 과정은 Test 코드로 검증을 진행하며 로직의 결과가 변질되지 않도록 주의할 것입니다. 🙋