### PR TITLE
chore : FoldersController, FoldersService 메서드 이름 변경, isPublic을 visible로 변경

### DIFF
--- a/src/main/java/com/Kkrap/Controller/FoldersController.java
+++ b/src/main/java/com/Kkrap/Controller/FoldersController.java
@@ -30,15 +30,15 @@ public class FoldersController {
     //Create
     // 1. 폴더를 만드는 api
     @PostMapping("/{userId}")
-    public ResponseEntity<FoldersResponse> CreateFolder(@PathVariable("userId") Long userId, @RequestBody FoldersCreateRequest foldersCreateRequest) {
-        return foldersService.CreateFolder(userId, foldersCreateRequest);
+    public ResponseEntity<FoldersResponse> createFolder(@PathVariable("userId") Long userId, @RequestBody FoldersCreateRequest foldersCreateRequest) {
+        return foldersService.createFolder(userId, foldersCreateRequest);
     }
 
     //Delete
     @DeleteMapping("/{userId}")
-    public ResponseEntity<FoldersResponse> DeleteFolder(@PathVariable("userId") Long userId, @RequestBody FoldersDeleteRequest foldersDeleteRequest)
+    public ResponseEntity<FoldersResponse> deleteFolder(@PathVariable("userId") Long userId, @RequestBody FoldersDeleteRequest foldersDeleteRequest)
     {
-        return foldersService.DeleteFolder(userId, foldersDeleteRequest);
+        return foldersService.deleteFolder(userId, foldersDeleteRequest);
     }
 
 }

--- a/src/main/java/com/Kkrap/Entity/Folders.java
+++ b/src/main/java/com/Kkrap/Entity/Folders.java
@@ -30,7 +30,7 @@ public class Folders {
     private String folderDescription;
 
     @Column(nullable = false)
-    private boolean isPublic;
+    private boolean visible;
 
     @ManyToOne
     @JoinColumn(name = "user_id", nullable = false)
@@ -40,20 +40,16 @@ public class Folders {
     @OneToMany(mappedBy = "folders", cascade = CascadeType.ALL)
     private List<FoldersLinks> foldersLinks;
 
-    public Folders(Users user, String folderName, String folderDescription, boolean isPublic) {
+    public Folders(Users user, String folderName, String folderDescription, boolean visible) {
         this.user = user;
         this.folderName = folderName;
         this.folderDescription = folderDescription;
-        this.isPublic = isPublic;
+        this.visible = visible;
     }
 
     private Folders() {} //외부에서 new 사용 못하게 보호
 
-    public boolean getIsPublic() {
-        return isPublic;
-    }
-
     public static Folders of(FoldersCreateRequest foldersCreateRequest, Users user){
-        return new Folders(user, foldersCreateRequest.getFolderName(), foldersCreateRequest.getFolderDescription(), foldersCreateRequest.getisPublic());
+        return new Folders(user, foldersCreateRequest.getFolderName(), foldersCreateRequest.getFolderDescription(), foldersCreateRequest.isVisible());
     }
 }

--- a/src/main/java/com/Kkrap/RequestDTO/FoldersCreateRequest.java
+++ b/src/main/java/com/Kkrap/RequestDTO/FoldersCreateRequest.java
@@ -10,20 +10,15 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 public class FoldersCreateRequest {
-    private Long userId;
 
     private String folderName;
 
     private String folderDescription;
 
-    private boolean isPublic;
+    private boolean visible;
 
-    public boolean getisPublic(){
-        return isPublic;
-    }
-
-    public static FoldersCreateRequest of(Long userId, String folderName, String folderDescription, boolean isPublic){
-        return new FoldersCreateRequest(userId, folderName, folderDescription, isPublic);
+    public static FoldersCreateRequest of(String folderName, String folderDescription, boolean visible){
+        return new FoldersCreateRequest(folderName, folderDescription, visible);
 
     }
 

--- a/src/main/java/com/Kkrap/ResponseDto/FoldersLinksAllResponse.java
+++ b/src/main/java/com/Kkrap/ResponseDto/FoldersLinksAllResponse.java
@@ -15,7 +15,7 @@ public class FoldersLinksAllResponse {
     private Long folderId;
     private String folderName;
     private String folderDescription;
-    private boolean isPublic;
+    private boolean visible;
     private LocalDateTime createTime;
     private List<LinksResponse> links;
 
@@ -25,11 +25,11 @@ public class FoldersLinksAllResponse {
         Long folderId = folder.getFolderId();
         String folderName = folder.getFolderName();
         String folderDescription = folder.getFolderDescription();
-        boolean isPublic = folder.getIsPublic();
+        boolean visible = folder.isVisible();
         LocalDateTime createTime = folder.getCreateTime();
         List<LinksResponse> links = linksList.stream()
                 .map(LinksResponse::new)
                 .collect(Collectors.toList());
-        return new FoldersLinksAllResponse(folderId, folderName, folderDescription, isPublic, createTime, links);
+        return new FoldersLinksAllResponse(folderId, folderName, folderDescription, visible, createTime, links);
     }
 }

--- a/src/main/java/com/Kkrap/ResponseDto/FoldersResponse.java
+++ b/src/main/java/com/Kkrap/ResponseDto/FoldersResponse.java
@@ -17,13 +17,13 @@ public class FoldersResponse {
     private String folderName;
     private String folderDescription;
     private LocalDateTime createTime;
-    private boolean isPublic;
+    private boolean visible;
 
     private FoldersResponse() {}
 
 
     public static FoldersResponse from(Folders folders){
-        return new FoldersResponse(folders.getFolderId(), folders.getFolderId(), folders.getFolderName(), folders.getFolderDescription(), folders.getCreateTime(), folders.getIsPublic());
+        return new FoldersResponse(folders.getFolderId(), folders.getFolderId(), folders.getFolderName(), folders.getFolderDescription(), folders.getCreateTime(), folders.isVisible());
     }
 
 }

--- a/src/main/java/com/Kkrap/Service/AuthService.java
+++ b/src/main/java/com/Kkrap/Service/AuthService.java
@@ -75,7 +75,7 @@ public class AuthService {
             UsersCreateRequest usersCreateRequest = UsersCreateRequest.of(email, nickname, profileImage, kakaoId);
             Users newUser = usersService.save(usersCreateRequest);
             // 처음 로그인 한 사람은 모든 링크 보기 폴더가 없음 만들어주어야함
-            FoldersCreateRequest foldersCreateRequest = FoldersCreateRequest.of(newUser.getUserId(), "모든 링크", "모든 링크가 저장된 폴더입니다.", false);
+            FoldersCreateRequest foldersCreateRequest = FoldersCreateRequest.of("모든 링크", "모든 링크가 저장된 폴더입니다.", false);
             foldersService.save(foldersCreateRequest, newUser);
             UsersProfileResponse usersProfileResponse = UsersProfileResponse.of(newUser.getUserId(), newUser.getEmail(), newUser.getNickname(), newUser.getProfile(), newUser.getKakaoId());
             return usersProfileResponse;

--- a/src/main/java/com/Kkrap/Service/FoldersService.java
+++ b/src/main/java/com/Kkrap/Service/FoldersService.java
@@ -60,7 +60,7 @@ public class FoldersService {
 
     //Create
     //폴더를 만드는 것
-    public ResponseEntity<FoldersResponse> CreateFolder(Long userId, FoldersCreateRequest foldersCreateRequest)
+    public ResponseEntity<FoldersResponse> createFolder(Long userId, FoldersCreateRequest foldersCreateRequest)
     {
         //사용자 조회
         Users users = usersService.findById(userId);
@@ -71,7 +71,7 @@ public class FoldersService {
 
     //Delete
     //폴더 삭제
-    public ResponseEntity<FoldersResponse> DeleteFolder(Long userId, FoldersDeleteRequest foldersDeleteRequest)
+    public ResponseEntity<FoldersResponse> deleteFolder(Long userId, FoldersDeleteRequest foldersDeleteRequest)
     {
         //사용자 체크
         usersService.findById(userId);


### PR DESCRIPTION
**변경사항**
- Folders에서 컨트롤러와 서비스에서 메서드 이름 변경
- isPublic이름으로 인한 문제로 밑 사진처럼 getisPublic을 볼 수가 있음 공개/비공개 변수 이름을 public으로하면 java에서 예약어라 에러가 터지고 변수 이름을 IsPublic으로 하면 getter에서 is를 자동으로 붙이는데 ispublic를 할 경우 IsisPublic이 되어 변수 이름을 visible로 변경 
![image](https://github.com/user-attachments/assets/20e90599-402b-4b26-bc0c-81a86ccf50fe)
