### PR TITLE
feat :  하나의 폴더 전체 링크 최신순 조회, 하나의 폴더 전체 링크 4개 최신순 조회(썸네일 전용), 모든 폴더 및 링크 조회 최신순 변경

### DIFF
--- a/src/main/java/com/Kkrap/Controller/FoldersController.java
+++ b/src/main/java/com/Kkrap/Controller/FoldersController.java
@@ -32,6 +32,15 @@ public class FoldersController {
         return foldersService.getFoldersAll(userId);
     }
 
+    //사용자 가지고 있는 모든 폴더 안에 있는 링크 4개만 -> 썸네일 전용
+    @GetMapping("/{userId}/thumbnailUrl")
+    @Operation(summary = "사용자의 모든 폴더 및 링크 최신순 4개", description = "보관함에서 보여줄 썸네일 전용")
+    public ResponseEntity<List<FoldersLinksAllResponse>> getFoldersAllthumbnailUrl(
+            @Parameter(name = "userId", description = "사용자 ID", required = true, example = "1")
+            @PathVariable("userId") Long userId){
+        return foldersService.getFoldersAllthumbnailUrl(userId);
+    }
+
     @GetMapping("/{folderId}/links")
     @Operation(summary = "하나의 폴더 링크 전체 조회", description = "하나의 폴더와 모든 링크 조회")
     public ResponseEntity<FoldersLinksAllResponse> getOneFolderLinksAll(

--- a/src/main/java/com/Kkrap/Controller/FoldersController.java
+++ b/src/main/java/com/Kkrap/Controller/FoldersController.java
@@ -32,6 +32,15 @@ public class FoldersController {
         return foldersService.getFoldersAll(userId);
     }
 
+    @GetMapping("/{folderId}/links")
+    @Operation(summary = "하나의 폴더 링크 전체 조회", description = "하나의 폴더와 모든 링크 조회")
+    public ResponseEntity<FoldersLinksAllResponse> getOneFolderLinksAll(
+            @Parameter(name = "folderId", description = "폴더 ID", required = true, example = "10")
+            @PathVariable("folderId") Long folderId
+    ){
+        return foldersService.getOneFolderLinksAll(folderId);
+    }
+
     //Create
     // 1. 폴더를 만드는 api
     @PostMapping("/{userId}")

--- a/src/main/java/com/Kkrap/Service/FoldersService.java
+++ b/src/main/java/com/Kkrap/Service/FoldersService.java
@@ -29,7 +29,7 @@ public class FoldersService {
     private FoldersRepository foldersRepository;
 
     @Autowired
-    private FoldersLinksRepository foldersLinksRepository;
+    private FoldersLinksService foldersLinksService;
 
     @Autowired
     private LinksRepository linksRepository;
@@ -43,7 +43,7 @@ public class FoldersService {
         List<FoldersLinksAllResponse> responseList = folders.stream().map(folder -> {
             // 해당 폴더의 FoldersLinks 조회 (folder_id 기준)
             // 특정 폴더(folder_id)에 해당하는 FoldersLinks를 조회
-            List<FoldersLinks> folderLinksList = foldersLinksRepository.findByFolders(folder);
+            List<FoldersLinks> folderLinksList = foldersLinksService.findByFolders(folder);
 
             // 각 FoldersLinks에서 link_id 추출하여 Links 조회
             List<Links> linksList = folderLinksList.stream()
@@ -56,6 +56,19 @@ public class FoldersService {
         return ResponseEntity.ok(responseList);
     }
 
+    public ResponseEntity<FoldersLinksAllResponse> getOneFolderLinksAll(Long folderId){
+        //폴더가 있는지 검사
+        Folders folder = findById(folderId);
+
+        //해당 폴더의 FoldersLinks 조회
+        List<FoldersLinks> folderLinksList = foldersLinksService.findByFolders(folder);
+        List<Links> linksList = folderLinksList.stream()
+                .map(folderLink -> linksRepository.findById(folderLink.getLinks().getLinkId()).orElse(null))
+                .filter(Objects::nonNull) // 존재하는 Links만 리스트에 추가
+                .collect(Collectors.toList());
+        // Folder + Links 리스트를 Response DTO로 변환
+        return ResponseEntity.ok(FoldersLinksAllResponse.of(folder, linksList));
+    }
 
     //Create
     //폴더를 만드는 것
@@ -78,10 +91,10 @@ public class FoldersService {
         //FolderLinks에 해당 folderId에 속한 FolderLinks 리스트 조회
         Long folderId = foldersDeleteRequest.getFolderId();
         Folders folders = findById(folderId);
-        List<FoldersLinks> folderLinksList = foldersLinksRepository.findByFolders(folders);
+        List<FoldersLinks> folderLinksList = foldersLinksService.findByFolders(folders);
 
         // FoldersLinks 테이블에서 해당 folderId를 가진 데이터 삭제 ---------------> 이거 해야됨
-        foldersLinksRepository.deleteAll(folderLinksList);
+        foldersLinksService.deleteAll(folderLinksList);
         // folders 삭제
         deleteById(folderId);
         //응답 데이터를 삭제된 링크들까지 포함 시켜서 해주어야함
@@ -103,6 +116,8 @@ public class FoldersService {
         }
         return folders;
     }
+
+
 
     //하나 폴더 조회
     public Folders findById(Long folderId){

--- a/src/main/java/com/Kkrap/Service/FoldersService.java
+++ b/src/main/java/com/Kkrap/Service/FoldersService.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -49,12 +50,37 @@ public class FoldersService {
             List<Links> linksList = folderLinksList.stream()
                     .map(folderLink -> linksRepository.findById(folderLink.getLinks().getLinkId()).orElse(null))
                     .filter(Objects::nonNull) // 존재하는 Links만 리스트에 추가
+                    .sorted(Comparator.comparing(Links::getCreateTime).reversed()) // 최신순 정렬
                     .collect(Collectors.toList());
             // Folder + Links 리스트를 Response DTO로 변환
             return FoldersLinksAllResponse.of(folder, linksList);
         }).collect(Collectors.toList());
         return ResponseEntity.ok(responseList);
     }
+
+    public ResponseEntity<List<FoldersLinksAllResponse>> getFoldersAllthumbnailUrl(Long userId){
+        //중간에 있는 사용자 인지 검사
+        usersService.findById(userId);
+        // userId를 통해 전부 가져오기
+        List<Folders> folders = findByUserUserId(userId);
+        List<FoldersLinksAllResponse> responseList = folders.stream().map(folder -> {
+            // 해당 폴더의 FoldersLinks 조회 (folder_id 기준)
+            // 특정 폴더(folder_id)에 해당하는 FoldersLinks를 조회
+            List<FoldersLinks> folderLinksList = foldersLinksService.findByFolders(folder);
+
+            // 각 FoldersLinks에서 link_id 추출하여 Links 조회
+            List<Links> linksList = folderLinksList.stream()
+                    .map(folderLink -> linksRepository.findById(folderLink.getLinks().getLinkId()).orElse(null))
+                    .filter(Objects::nonNull) // 존재하는 Links만 리스트에 추가
+                    .sorted(Comparator.comparing(Links::getCreateTime).reversed()) // 최신순 정렬
+                    .limit(4) // 상위 4개만 추출
+                    .collect(Collectors.toList());
+            // Folder + Links 리스트를 Response DTO로 변환
+            return FoldersLinksAllResponse.of(folder, linksList);
+        }).collect(Collectors.toList());
+        return ResponseEntity.ok(responseList);
+    }
+
 
     public ResponseEntity<FoldersLinksAllResponse> getOneFolderLinksAll(Long folderId){
         //폴더가 있는지 검사
@@ -65,6 +91,7 @@ public class FoldersService {
         List<Links> linksList = folderLinksList.stream()
                 .map(folderLink -> linksRepository.findById(folderLink.getLinks().getLinkId()).orElse(null))
                 .filter(Objects::nonNull) // 존재하는 Links만 리스트에 추가
+                .sorted(Comparator.comparing(Links::getCreateTime).reversed()) // 최신순 정렬
                 .collect(Collectors.toList());
         // Folder + Links 리스트를 Response DTO로 변환
         return ResponseEntity.ok(FoldersLinksAllResponse.of(folder, linksList));


### PR DESCRIPTION
**변경사항**
- 하나의 폴더와 안에 있는 모든 링클르 조회하는 기능 추가
- 썸네일 전용 하나의 폴더와 안에 있는 링크 최신순으로 4개만 보여주는 기능 추가
- 모든 폴더 및 링크 조회에서 안에 링크들 최신순으로 조회

참고
- 썸네일 전용은 프론트 분들이 요청하셔서 하나 따로 만들었습니다.