### PR TITLE
refactor: AuthService 리팩토링

### DIFF
--- a/src/main/java/com/Kkrap/Controller/AuthController.java
+++ b/src/main/java/com/Kkrap/Controller/AuthController.java
@@ -26,7 +26,7 @@ public class AuthController {
     @PostMapping("/kakao-login")
     @Operation(summary = "카카오 로그인", description = "카카오 서버에서 인가 코드를 통해 로그인 진행하시고 토큰 요청을 보내 받은 걸 이 api에 던져주시면 됩니다")
     public ResponseEntity<UsersProfileResponse> kakaoLogin(@RequestBody KaKaoTokenRequest request){
-        var response = authService.kakaoLogin(request);
+        var response = authService.prepare(request);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/Kkrap/Service/AuthService.java
+++ b/src/main/java/com/Kkrap/Service/AuthService.java
@@ -21,44 +21,19 @@ import java.util.Optional;
 @Service
 public class AuthService {
 
-    public static final String KAKAO_USER_INFO_URL = "https://kapi.kakao.com/v2/user/me";
+    private final UsersService usersService;
 
-    @Autowired
-    UsersRepository usersRepository;
+    private final FoldersService foldersService;
 
-    @Autowired
-    UsersService usersService;
+    private final KakaoClientProvider kakaoClientProvider;
 
-    @Autowired
-    FoldersService foldersService;
-
-    public boolean isAccessToken(String token) {
-        if(token.equals("")){
-            throw NotValidTokenException.from("토큰이 없습니다.");
-        }
-        return false;
+    public AuthService(UsersRepository usersRepository, UsersService usersService, FoldersService foldersService) {
+        this.usersService = usersService;
+        this.foldersService = foldersService;
+        this.kakaoClientProvider = new KakaoClientProvider();
     }
 
-    private Map<String, Object> getKakaoUserInfo(String accessToken){
-        try {
-            HttpHeaders headers = new HttpHeaders();
-            headers.setBearerAuth(accessToken);
-            HttpEntity<?> entity = new HttpEntity<>(headers);
-
-            ResponseEntity<Map> response = new RestTemplate().exchange(
-                    KAKAO_USER_INFO_URL,
-                    HttpMethod.GET,
-                    entity,
-                    Map.class
-            );
-
-            return response.getBody();
-        } catch (Exception e) {
-            throw NotValidTokenException.from("유효하지 않은 카카오 액세스 토큰입니다.");
-        }
-    }
-
-    public UsersProfileResponse kakaoLogin(@RequestBody KaKaoTokenRequest request){
+    public UsersProfileResponse prepare(@RequestBody KaKaoTokenRequest request) {
         String accessToken = request.getAccesstoken();
 
         if (accessToken.isEmpty()){
@@ -66,20 +41,40 @@ public class AuthService {
         }
 
         //1. 카카오 유저 정보 요청
-        Map<String, Object> userInfo = getKakaoUserInfo(accessToken);
+        Map<String, Object> userInfo = kakaoClientProvider.getClient(accessToken);
+
         Long kakaoId = Long.valueOf(userInfo.get("id").toString());
         Map<String, Object> kakaoAccount = (Map<String, Object>) userInfo.get("kakao_account");
         Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
-
         String email = kakaoAccount.get("email").toString();
         String nickname = profile.get("nickname").toString();
         String profileImage = profile.get("profile_image_url").toString();
 
-        Optional<Users> CheckUser = usersRepository.findByKaKaoId(Long.valueOf(kakaoId));
+        UsersProfileResponse response = validateUser(email, nickname, profileImage, kakaoId);
+
+        return response;
+    }
+
+    private boolean isAccessToken(String token) {
+        if(token == null){
+            throw new NotValidTokenException("토큰이 없습니다.");
+        }
+
+        if(token.equals("")){
+            throw new NotValidTokenException("토큰이 없습니다.");
+        }
+
+        return false;
+    }
+
+    private UsersProfileResponse validateUser(String email, String nickname, String profileImage, Long kakaoId) {
+        Optional<Users> CheckUser = usersService.findByKakaoId(Long.valueOf(kakaoId));
         if (CheckUser.isEmpty()){
+
             // 처음 로그인 한 사람 사용자 만들기
             UsersCreateRequest usersCreateRequest = UsersCreateRequest.of(email, nickname, profileImage, kakaoId, null);
             Users newUser = usersService.save(usersCreateRequest);
+
             // 처음 로그인 한 사람은 모든 링크 보기 폴더가 없음 만들어주어야함
             FoldersCreateRequest foldersCreateRequest = FoldersCreateRequest.of("모든 링크", "모든 링크가 저장된 폴더입니다.", false);
             foldersService.save(foldersCreateRequest, newUser);

--- a/src/main/java/com/Kkrap/Service/ClientProvider.java
+++ b/src/main/java/com/Kkrap/Service/ClientProvider.java
@@ -1,0 +1,9 @@
+package com.Kkrap.Service;
+
+import java.util.Map;
+
+public interface ClientProvider {
+
+    Map<String, Object> getClient(String accessToken);
+
+}

--- a/src/main/java/com/Kkrap/Service/KakaoClientProvider.java
+++ b/src/main/java/com/Kkrap/Service/KakaoClientProvider.java
@@ -1,0 +1,35 @@
+package com.Kkrap.Service;
+
+import com.Kkrap.Exception.NotValidTokenException;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+public class KakaoClientProvider implements ClientProvider{
+
+    public static final String KAKAO_USER_INFO_URL = "https://kapi.kakao.com/v2/user/me";
+
+    @Override
+    public Map<String, Object> getClient(String accessToken) {
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.setBearerAuth(accessToken);
+            HttpEntity<?> entity = new HttpEntity<>(headers);
+
+            ResponseEntity<Map> response = new RestTemplate().exchange(
+                    KAKAO_USER_INFO_URL,
+                    HttpMethod.GET,
+                    entity,
+                    Map.class
+            );
+
+            return response.getBody();
+        } catch (Exception e) {
+            throw NotValidTokenException.from("유효하지 않은 카카오 액세스 토큰입니다.");
+        }
+    }
+}

--- a/src/main/java/com/Kkrap/Service/UsersService.java
+++ b/src/main/java/com/Kkrap/Service/UsersService.java
@@ -13,15 +13,14 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.Optional;
+
 
 @Service
 public class UsersService {
 
     @Autowired
     private UsersRepository usersRepository;
-
-
-
 
     public ResponseEntity<UsersProfileResponse> getUserProfile(Long userId){
         Users users = findById(userId);
@@ -75,6 +74,10 @@ public class UsersService {
     //유저 이미 있는데 저장
     public Users save(Users users){
         return usersRepository.save(users);
+    }
+
+    public Optional<Users> findByKakaoId(Long id) {
+        return usersRepository.findByKaKaoId(id);
     }
 
 }

--- a/src/test/java/com/Kkrap/Auth/AuthServiceTest.java
+++ b/src/test/java/com/Kkrap/Auth/AuthServiceTest.java
@@ -25,6 +25,7 @@ public class AuthServiceTest {
         String id = "hello123";
         String emptyToken = "";
         String validToken = Base64.getEncoder().encodeToString(id.getBytes());
+        String nullToken = null;
         System.out.println(validToken);
 
         assertThrows(NotValidTokenException.class, () -> {
@@ -32,9 +33,11 @@ public class AuthServiceTest {
         });
 
         var result = authService.isAccessToken(validToken);
+        var result2 = authService.isAccessToken(nullToken);
 
         Assertions.assertThat(result).isNotNull();
         Assertions.assertThat(result).isEqualTo(false);
+        Assertions.assertThat(result2).isNotNull();
     }
 
 }

--- a/src/test/java/com/Kkrap/Auth/OauthTest.java
+++ b/src/test/java/com/Kkrap/Auth/OauthTest.java
@@ -1,0 +1,34 @@
+package com.Kkrap.Auth;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+import java.util.Map;
+
+@WebMvcTest
+@AutoConfigureMockMvc
+public class OauthTest {
+
+    @Autowired private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("카카오 로그인 성공 테스트")
+    void kakaoLogin() {
+        OAuth2User user = new DefaultOAuth2User(
+                Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")),
+                Map.of("id", "123456", "email", ""),
+                "id"
+        );
+
+        // 작업 예정
+    }
+
+}

--- a/src/test/java/com/Kkrap/Auth/TokenStubFunction.java
+++ b/src/test/java/com/Kkrap/Auth/TokenStubFunction.java
@@ -1,0 +1,17 @@
+package com.Kkrap.Auth;
+
+import com.Kkrap.Exception.NotValidTokenException;
+
+public class TokenStubFunction {
+    public static boolean isAccessToken(String token) {
+        if(token == null){
+            throw new NotValidTokenException("토큰이 없습니다.");
+        }
+
+        if(token.equals("")){
+            throw new NotValidTokenException("토큰이 없습니다.");
+        }
+
+        return false;
+    }
+}

--- a/src/test/java/com/Kkrap/Auth/TokenTest.java
+++ b/src/test/java/com/Kkrap/Auth/TokenTest.java
@@ -3,6 +3,7 @@ package com.Kkrap.Auth;
 import com.Kkrap.Exception.NotValidTokenException;
 import com.Kkrap.RequestDTO.KaKaoTokenRequest;
 import com.Kkrap.Service.AuthService;
+import org.antlr.v4.runtime.Token;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,14 +13,11 @@ import java.util.Base64;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@SpringBootTest
-public class AuthServiceTest {
+public class TokenTest {
 
-    @Autowired AuthService authService;
-
+    TokenStubFunction tokenStubFunction;
 
     // 연동 로그인 종류에 맞춰서 확장성을 고려한 추상화가 필요할 수 있음
-
     @Test
     void isAccessToken() {
         String id = "hello123";
@@ -29,15 +27,17 @@ public class AuthServiceTest {
         System.out.println(validToken);
 
         assertThrows(NotValidTokenException.class, () -> {
-            authService.isAccessToken(emptyToken);
+            tokenStubFunction.isAccessToken(emptyToken);
         });
 
-        var result = authService.isAccessToken(validToken);
-        var result2 = authService.isAccessToken(nullToken);
+        assertThrows(NotValidTokenException.class, () -> {
+            tokenStubFunction.isAccessToken(nullToken);
+        });
+
+        var result = tokenStubFunction.isAccessToken(validToken);
 
         Assertions.assertThat(result).isNotNull();
         Assertions.assertThat(result).isEqualTo(false);
-        Assertions.assertThat(result2).isNotNull();
     }
 
 }


### PR DESCRIPTION
### 문제 사항

- AuthService는 카카오 로그인 정보를 가지고 있는 상태
- 하나의 메소드에 너무 많은 기능들이 동작함
- 카카오 로그인 외에 다른 로그인 기능이 필요하거나 수정할 때, 가독성을 가지기 힘듬

### 구조 개선

![image](https://github.com/user-attachments/assets/8c08f5cf-e822-4563-bb98-8080217532ee)

- AuthService가 알고있는 카카오 로그인 정보를 하위 클래스(KakaoClientProvider 정보제공자)에게 분리, 추후 추가 클라이언트 구현을 고려한 인터페이스 분리를 진행
- AuthService는 로그인 시도 및 토큰 검증 메소드만을 가짐

### 추후 개선 사항

- AuthService 기능 및 변수 , 메소드 네이밍을 가독성을 향상시킬 수 있을것으로 보임 -> 추가 개선이 가능한 시간대에 변경 예정

- oauth 테스트 코드 추가 구성 예정