### PR TITLE
Feature/#40

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,10 @@ dependencies {
 	//kafka
 	implementation 'org.springframework.kafka:spring-kafka'
 
+	//elasticsearch
+	implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+	implementation 'org.springframework.retry:spring-retry'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/Kkrap/Controller/AuthController.java
+++ b/src/main/java/com/Kkrap/Controller/AuthController.java
@@ -1,11 +1,9 @@
 package com.Kkrap.Controller;
 
 import com.Kkrap.RequestDTO.KaKaoTokenRequest;
-import com.Kkrap.ResponseDto.UsersProfileResponse;
+import com.Kkrap.ResponseDTO.UsersProfileResponse;
 import com.Kkrap.Service.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/src/main/java/com/Kkrap/Controller/FoldersController.java
+++ b/src/main/java/com/Kkrap/Controller/FoldersController.java
@@ -6,6 +6,7 @@ import com.Kkrap.RequestDTO.FoldersDeleteRequest;
 import com.Kkrap.RequestDTO.FoldersUpdateRequest;
 import com.Kkrap.ResponseDTO.FoldersResponse;
 import com.Kkrap.ResponseDTO.FoldersLinksAllResponse;
+import com.Kkrap.ResponseDTO.UserFoldersWithSharedResponse;
 import com.Kkrap.Service.FolderLink.FoldersManagerService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -29,11 +30,51 @@ public class FoldersController {
     //사용자가 가지고 있는 모든 폴더와 내안 있는 링크들 같이 조회
     @GetMapping("/users/{userId}/folders")
     @Operation(summary = "사용자의 모든 폴더 및 모든 링크", description = "한 명의 사용자가 가진 모든 폴더와 모든 링크 조회")
-    public ResponseEntity<List<FoldersLinksAllResponse>> getUserAllFoldersWithLinks(
+    public ResponseEntity<UserFoldersWithSharedResponse> getUserAllFoldersWithLinks(
             @Parameter(name = "userId", description = "사용자 ID", required = true, example = "1")
             @PathVariable("userId") Long userId){
         return foldersManagerService.getUserAllFoldersWithLinks(userId);
     }
+
+
+
+    //상대방이 가지고 있는 모든 폴더 안에 있는 링크 4개만 -> 썸네일 전용
+    @GetMapping("/users/{userId}/folders/thumbnails")
+    @Operation(summary = "상대방의 모든 폴더 및 링크 최신순 4개", description = "상대방 보관함에서 보여줄 썸네일 전용")
+    public ResponseEntity<UserFoldersWithSharedResponse> getAllFoldersWithTop4LinksByUser(
+            @Parameter(name = "userId", description = "사용자 ID", required = true, example = "1")
+            @PathVariable("userId") Long userId){
+        return foldersManagerService.getAllFoldersWithTop4LinksByUser(userId);
+    }
+
+    //내가 가지고 있는 모든 폴더 안에 있는 링크 4개만 -> 썸네일 전용
+    @GetMapping("/users/{userId}/folders/thumbnails/me")
+    @Operation(summary = "내꺼 모든 폴더 및 링크 최신순 4개", description = "내꺼 보관함에서 보여줄 썸네일 전용")
+    public ResponseEntity<UserFoldersWithSharedResponse> getMeAllFoldersWithTop4Links(
+            @Parameter(name = "userId", description = "사용자 ID", required = true, example = "1")
+            @PathVariable("userId") Long userId){
+        return foldersManagerService.getMeAllFoldersWithTop4Links(userId);
+    }
+
+    //조회수 -> Redis -> Kafka
+    @GetMapping("/users/{userId}/folders/{folderId}/links")
+    @Operation(summary = "상대방 하나의 폴더 링크 전체 조회", description = "상대방 하나의 폴더와 모든 링크 조회")
+    public ResponseEntity<FoldersLinksAllResponse> getOneFolderWithLinksByUser(
+            @PathVariable("userId") Long userId,
+            @PathVariable("folderId") Long folderId
+    ){
+        return foldersManagerService.getOneFolderWithLinksByUser(userId, folderId);
+    }
+
+    @GetMapping("/me/folders/{folderId}/links")
+    @Operation(summary = "나의 하나 폴더 링크 전체 조회", description = "나의 하나 폴더와 모든 링크 조회")
+    public ResponseEntity<FoldersLinksAllResponse> getMyOneFolderWithLinks(
+            @Parameter(name = "folderId", description = "폴더 ID", required = true, example = "10")
+            @PathVariable("folderId") Long folderId
+    ){
+        return foldersManagerService.getMyOneFolderWithLinks(folderId);
+    }
+
 
     //Create
     // 1. 폴더를 만드는 api
@@ -55,41 +96,9 @@ public class FoldersController {
         return foldersManagerService.deleteUserFolder(userId, foldersDeleteRequest);
     }
 
-
-    //사용자 가지고 있는 모든 폴더 안에 있는 링크 4개만 -> 썸네일 전용
-    @GetMapping("/users/{userId}/folders/thumbnails")
-    @Operation(summary = "사용자의 모든 폴더 및 링크 최신순 4개", description = "보관함에서 보여줄 썸네일 전용")
-    public ResponseEntity<List<FoldersLinksAllResponse>> getUserAllFoldersWithTop4Links(
-            @Parameter(name = "userId", description = "사용자 ID", required = true, example = "1")
-            @PathVariable("userId") Long userId){
-        return foldersManagerService.getUserAllFoldersWithTop4Links(userId);
-    }
-
-    //조회수 -> Redis -> Kafka
-    @GetMapping("/users/{userId}/folders/{folderId}/links")
-    @Operation(summary = "상대방 하나의 폴더 링크 전체 조회", description = "상대방 하나의 폴더와 모든 링크 조회")
-    public ResponseEntity<FoldersLinksAllResponse> getOneFolderWithLinksByUser(
-            @PathVariable("userId") Long userId,
-            @PathVariable("folderId") Long folderId
-            ){
-        return foldersManagerService.getOneFolderWithLinksByUser(userId, folderId);
-    }
-
-    @GetMapping("/me/folders/{folderId}/links")
-    @Operation(summary = "나의 하나 폴더 링크 전체 조회", description = "나의 하나 폴더와 모든 링크 조회")
-    public ResponseEntity<FoldersLinksAllResponse> getMyOneFolderWithLinks(
-            @Parameter(name = "folderId", description = "폴더 ID", required = true, example = "10")
-            @PathVariable("folderId") Long folderId
-    ){
-        return foldersManagerService.getMyOneFolderWithLinks(folderId);
-    }
-
     @PatchMapping("/{folderId}") // 폴더 제목, 설명, 공개비공개 수정
     @Operation(summary = "폴더 제목, 설명, 공개비공개 수정", description = "userId와 folderId가 필요")
     public ResponseEntity<FoldersResponse> updateFolderMetadata(@RequestBody FoldersUpdateRequest request){
         return foldersManagerService.updateFolderMetadata(request);
     }
-
-
-
 }

--- a/src/main/java/com/Kkrap/Controller/FoldersController.java
+++ b/src/main/java/com/Kkrap/Controller/FoldersController.java
@@ -4,8 +4,8 @@ import com.Kkrap.RequestDTO.FoldersCreateRequest;
 
 import com.Kkrap.RequestDTO.FoldersDeleteRequest;
 import com.Kkrap.RequestDTO.FoldersUpdateRequest;
-import com.Kkrap.ResponseDto.FoldersResponse;
-import com.Kkrap.ResponseDto.FoldersLinksAllResponse;
+import com.Kkrap.ResponseDTO.FoldersResponse;
+import com.Kkrap.ResponseDTO.FoldersLinksAllResponse;
 import com.Kkrap.Service.FolderLink.FoldersManagerService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;

--- a/src/main/java/com/Kkrap/Controller/FoldersDocumentController.java
+++ b/src/main/java/com/Kkrap/Controller/FoldersDocumentController.java
@@ -46,7 +46,7 @@ public class FoldersDocumentController {
     }
 
     @GetMapping("/rankings")
-    @Operation(summary = "주간 랭킹 조회", description = "viewCount, likesCount Top10 반환")
+    @Operation(summary = "주간 랭킹 조회", description = "viewCount, scrapCount Top10 반환")
     public ResponseEntity<ElasticSearchRankingResponse> getWeeklyRankings() {
         return ResponseEntity.ok(foldersDocumentManagerService.getWeeklyRankings());
     }

--- a/src/main/java/com/Kkrap/Controller/FoldersDocumentController.java
+++ b/src/main/java/com/Kkrap/Controller/FoldersDocumentController.java
@@ -26,14 +26,14 @@ public class FoldersDocumentController {
     }
 
     @DeleteMapping("/all")
-    @Operation(summary = "색인 된 거 전부 삭제", description = "색인 된 거 전부 삭제")
+    @Operation(summary = "색인 된 거 전부 삭제 - 프론트엔드 사용금지", description = "색인 된 거 전부 삭제")
     public String deleteAll() {
         foldersDocumentManagerService.deleteAllDocuments();
         return "모든 색인 삭제 완료!";
     }
 
     @PostMapping("/migrate")
-    @Operation(summary = "DB에 저장된 모든 폴더 공개인 것만 넣어주기", description = "DB에 저장된 모든 폴더 공개인 것만 넣어주기")
+    @Operation(summary = "DB에 저장된 모든 폴더 공개인 것만 넣어주기 - 프론트엔드 사용금지", description = "DB에 저장된 모든 폴더 공개인 것만 넣어주기")
     public String migrate() {
         foldersDocumentManagerService.migrateAllFoldersToElasticsearch();
         return "마이그레이션 완료!";

--- a/src/main/java/com/Kkrap/Controller/FoldersDocumentController.java
+++ b/src/main/java/com/Kkrap/Controller/FoldersDocumentController.java
@@ -1,0 +1,65 @@
+package com.Kkrap.Controller;
+
+import com.Kkrap.ElasticSearch.FoldersDocument;
+import com.Kkrap.ResponseDTO.ElasticSearchRankingResponse;
+import com.Kkrap.Service.FoldersDocument.FoldersDocumentManagerService;
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/folders-search")
+public class FoldersDocumentController {
+
+    private final FoldersDocumentManagerService foldersDocumentManagerService;
+
+    public FoldersDocumentController(FoldersDocumentManagerService foldersDocumentManagerService){
+        this.foldersDocumentManagerService = foldersDocumentManagerService;
+    }
+
+    @GetMapping("/all")
+    @Operation(summary = "색인 된 거 전부 조회", description = "색인된 거 전부 조회")
+    public List<FoldersDocument> getAllDocuments() {
+        return foldersDocumentManagerService.getAllDocuments();
+    }
+
+    @DeleteMapping("/all")
+    @Operation(summary = "색인 된 거 전부 삭제", description = "색인 된 거 전부 삭제")
+    public String deleteAll() {
+        foldersDocumentManagerService.deleteAllDocuments();
+        return "모든 색인 삭제 완료!";
+    }
+
+    @PostMapping("/migrate")
+    @Operation(summary = "DB에 저장된 모든 폴더 공개인 것만 넣어주기", description = "DB에 저장된 모든 폴더 공개인 것만 넣어주기")
+    public String migrate() {
+        foldersDocumentManagerService.migrateAllFoldersToElasticsearch();
+        return "마이그레이션 완료!";
+    }
+
+    @GetMapping("/search")
+    @Operation(summary = "검색바에서 폴더 검색", description = "검색바에서 폴더 검색")
+    public ResponseEntity<List<FoldersDocument>> searchFolders(@RequestParam String keyword) {
+        return ResponseEntity.ok(foldersDocumentManagerService.searchFolders(keyword));
+    }
+
+    @GetMapping("/rankings")
+    @Operation(summary = "주간 랭킹 조회", description = "viewCount, likesCount Top10 반환")
+    public ResponseEntity<ElasticSearchRankingResponse> getWeeklyRankings() {
+        return ResponseEntity.ok(foldersDocumentManagerService.getWeeklyRankings());
+    }
+
+
+
+//    @GetMapping("/search")
+//    public List<FoldersDocument> searchFolders(@RequestParam String keyword) {
+//        return foldersDocumentManagerService.searchFolders(keyword);
+//    }
+
+//    @PostMapping("/index")
+//    public FoldersDocument indexFolder(@RequestBody Folders folder) {
+//        return foldersDocumentManagerService.indexNewFolder(folder);
+//    }
+}

--- a/src/main/java/com/Kkrap/Controller/FoldersPermissionsController.java
+++ b/src/main/java/com/Kkrap/Controller/FoldersPermissionsController.java
@@ -1,0 +1,40 @@
+package com.Kkrap.Controller;
+
+import com.Kkrap.RequestDTO.FoldersPermissionsCreateRequest;
+import com.Kkrap.RequestDTO.FoldersPermissionsDeleteRequest;
+import com.Kkrap.Service.FollowsFoldersPermission.FoldersPermissionsManagerService;
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+
+@RestController
+@RequestMapping("/folderspermissions")
+public class FoldersPermissionsController {
+
+    private final FoldersPermissionsManagerService foldersPermissionsManagerService;
+
+    public FoldersPermissionsController(FoldersPermissionsManagerService foldersPermissionsManagerService){
+        this.foldersPermissionsManagerService = foldersPermissionsManagerService;
+    }
+
+    @PostMapping("/{userId}/share")
+    @Operation(summary = "폴더 공유", description = "특정 폴더를 여러 사용자에게 공유합니다.")
+    public ResponseEntity<FoldersPermissionsCreateRequest> shareFolderWithUsers(
+            @PathVariable("userId") Long userId,
+            @RequestBody FoldersPermissionsCreateRequest request) {
+        return foldersPermissionsManagerService.shareFolderWithUsers(userId, request);
+    }
+
+    @DeleteMapping("/{userId}/share")
+    @Operation(summary = "폴더 공유 권한 삭제", description = "특정 사용자에 대한 폴더 공유를 취소합니다.")
+    public ResponseEntity<FoldersPermissionsDeleteRequest> revokeFolderPermission(
+            @PathVariable("userId") Long userId,
+            @RequestBody FoldersPermissionsDeleteRequest request) {
+        return foldersPermissionsManagerService.revokeFolderPermission(userId, request);
+    }
+
+
+
+
+}

--- a/src/main/java/com/Kkrap/Controller/FollowsController.java
+++ b/src/main/java/com/Kkrap/Controller/FollowsController.java
@@ -1,0 +1,53 @@
+package com.Kkrap.Controller;
+
+
+import com.Kkrap.RequestDTO.FollowsRequest;
+import com.Kkrap.ResponseDto.FollowsResponse;
+import com.Kkrap.ResponseDto.MessageResponse;
+import com.Kkrap.ResponseDto.UsersProfileResponse;
+import com.Kkrap.Service.Follows.FollowsManagerService;
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/follows")
+public class FollowsController {
+
+    private final FollowsManagerService followsManagerService;
+
+    public FollowsController(FollowsManagerService followsManagerService){
+        this.followsManagerService = followsManagerService;
+    }
+
+    //사용자가 팔로우 진행
+    @PostMapping("/{userId}/follow")
+    @Operation(summary = "팔로우 하기", description = "상대방을 팔로우")
+    public ResponseEntity<FollowsResponse> followUser(
+            @PathVariable("userId") Long followerId,
+            @RequestBody FollowsRequest request) {
+        return followsManagerService.followUser(followerId, request.getFollowingId());
+    }
+
+    //사용자 팔로우 삭제
+    @DeleteMapping("/{userId}/unfollow")
+    @Operation(summary = "팔로우 취소", description = "해당 사용자의 팔로우를 취소")
+    public ResponseEntity<FollowsResponse> unFollowUser(
+            @PathVariable("userId") Long followerId,
+            @RequestBody FollowsRequest request) {
+        return followsManagerService.unFollowUser(followerId, request.getFollowingId());
+    }
+
+    //팔로우 기능을 위한 사용자 조회
+    @GetMapping("/search")
+    @Operation(summary = "닉네임 포함 사용자 검색", description = "입력한 닉네임 문자열이 포함된 사용자들을 조회합니다.")
+    public ResponseEntity<List<UsersProfileResponse>> searchUsersByNicknameContains(
+            @RequestParam String nickname) {
+        return followsManagerService.findUsersByNicknameContains(nickname);
+    }
+
+
+
+}

--- a/src/main/java/com/Kkrap/Controller/FollowsController.java
+++ b/src/main/java/com/Kkrap/Controller/FollowsController.java
@@ -3,9 +3,8 @@ package com.Kkrap.Controller;
 
 import com.Kkrap.RequestDTO.FollowsRequest;
 import com.Kkrap.ResponseDto.FollowsResponse;
-import com.Kkrap.ResponseDto.MessageResponse;
 import com.Kkrap.ResponseDto.UsersProfileResponse;
-import com.Kkrap.Service.Follows.FollowsManagerService;
+import com.Kkrap.Service.FollowsFoldersPermission.FollowsManagerService;
 import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -20,6 +19,14 @@ public class FollowsController {
 
     public FollowsController(FollowsManagerService followsManagerService){
         this.followsManagerService = followsManagerService;
+    }
+
+    //현재 팔로우 중인 리스트 조회 -> 권한 부여를 위해 필요함
+    @GetMapping("/{userId}/following")
+    @Operation(summary = "팔로우 조회", description = "팔로우 조회")
+    public ResponseEntity<List<FollowsResponse>> getFollowingList(
+            @PathVariable("userId") Long followerId) {
+        return followsManagerService.getFollowingList(followerId);
     }
 
     //사용자가 팔로우 진행
@@ -47,6 +54,7 @@ public class FollowsController {
             @RequestParam String nickname) {
         return followsManagerService.findUsersByNicknameContains(nickname);
     }
+
 
 
 

--- a/src/main/java/com/Kkrap/Controller/FollowsController.java
+++ b/src/main/java/com/Kkrap/Controller/FollowsController.java
@@ -2,8 +2,8 @@ package com.Kkrap.Controller;
 
 
 import com.Kkrap.RequestDTO.FollowsRequest;
-import com.Kkrap.ResponseDto.FollowsResponse;
-import com.Kkrap.ResponseDto.UsersProfileResponse;
+import com.Kkrap.ResponseDTO.FollowsResponse;
+import com.Kkrap.ResponseDTO.UsersProfileResponse;
 import com.Kkrap.Service.FollowsFoldersPermission.FollowsManagerService;
 import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/Kkrap/Controller/LinksController.java
+++ b/src/main/java/com/Kkrap/Controller/LinksController.java
@@ -2,7 +2,7 @@ package com.Kkrap.Controller;
 
 import com.Kkrap.RequestDTO.LinksCreateRequest;
 import com.Kkrap.RequestDTO.LinksDeleteRequest;
-import com.Kkrap.ResponseDto.LinksCreateResponse;
+import com.Kkrap.ResponseDTO.LinksCreateResponse;
 import com.Kkrap.Service.FolderLink.LinksManagerService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;

--- a/src/main/java/com/Kkrap/Controller/UsersController.java
+++ b/src/main/java/com/Kkrap/Controller/UsersController.java
@@ -1,10 +1,8 @@
 package com.Kkrap.Controller;
 
-import com.Kkrap.Entity.Users;
-import com.Kkrap.RequestDTO.FollowsRequest;
 import com.Kkrap.RequestDTO.ProfileUpdateRequest;
-import com.Kkrap.ResponseDto.MessageResponse;
-import com.Kkrap.ResponseDto.UsersProfileResponse;
+import com.Kkrap.ResponseDTO.MessageResponse;
+import com.Kkrap.ResponseDTO.UsersProfileResponse;
 import com.Kkrap.Service.Users.UsersManagerService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -12,9 +10,6 @@ import io.swagger.v3.oas.annotations.media.Content;
 import org.springframework.http.*;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/users")

--- a/src/main/java/com/Kkrap/Controller/UsersController.java
+++ b/src/main/java/com/Kkrap/Controller/UsersController.java
@@ -1,5 +1,7 @@
 package com.Kkrap.Controller;
 
+import com.Kkrap.Entity.Users;
+import com.Kkrap.RequestDTO.FollowsRequest;
 import com.Kkrap.RequestDTO.ProfileUpdateRequest;
 import com.Kkrap.ResponseDto.MessageResponse;
 import com.Kkrap.ResponseDto.UsersProfileResponse;
@@ -10,6 +12,9 @@ import io.swagger.v3.oas.annotations.media.Content;
 import org.springframework.http.*;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/users")
@@ -65,4 +70,10 @@ public class UsersController {
             @RequestParam String nickname){
         return usersManagerService.checkNicknameAvailable(nickname);
     }
+
+
+
+
+
+
 }

--- a/src/main/java/com/Kkrap/ElasticSearch/ElasticsearchConfig.java
+++ b/src/main/java/com/Kkrap/ElasticSearch/ElasticsearchConfig.java
@@ -1,0 +1,19 @@
+package com.Kkrap.ElasticSearch;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.data.elasticsearch.client.elc.ElasticsearchTemplate;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
+
+@Configuration
+@EnableElasticsearchRepositories
+public class ElasticsearchConfig {
+    @Bean
+    @Lazy
+    public ElasticsearchOperations elasticsearchTemplate(ElasticsearchClient client) {
+        return new ElasticsearchTemplate(client);
+    }
+}

--- a/src/main/java/com/Kkrap/ElasticSearch/FoldersDocument.java
+++ b/src/main/java/com/Kkrap/ElasticSearch/FoldersDocument.java
@@ -1,0 +1,49 @@
+package com.Kkrap.ElasticSearch;
+
+import com.Kkrap.Entity.Folders;
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+
+import java.time.LocalDateTime;
+
+@Document(indexName = "folders")
+@Getter
+@Setter
+@AllArgsConstructor
+public class FoldersDocument {
+
+    @Id
+    private Long folderId;
+
+    private String folderName;
+    private String folderDescription;
+    private String createTime;
+    private Boolean visible;
+
+    private Long viewCount;
+    private Long likesCount;
+
+    private Long userId;
+    private String nickname;
+    private String profileImage;
+
+
+    private FoldersDocument(){}
+
+    public static FoldersDocument from(Folders folder) {
+        return new FoldersDocument(
+                folder.getFolderId(),
+                folder.getFolderName(),
+                folder.getFolderDescription(),
+                folder.getCreateTime() != null ? folder.getCreateTime().toString() : null,
+                folder.isVisible(),
+                folder.getViewCount(),
+                folder.getLikesCount(),
+                folder.getUser().getUserId(),
+                folder.getUser().getNickname(),
+                folder.getUser().getProfile()
+        );
+    }
+
+}

--- a/src/main/java/com/Kkrap/ElasticSearch/FoldersDocument.java
+++ b/src/main/java/com/Kkrap/ElasticSearch/FoldersDocument.java
@@ -22,7 +22,7 @@ public class FoldersDocument {
     private Boolean visible;
 
     private Long viewCount;
-    private Long likesCount;
+    private Long scrapCount;
 
     private Long userId;
     private String nickname;
@@ -39,7 +39,7 @@ public class FoldersDocument {
                 folder.getCreateTime() != null ? folder.getCreateTime().toString() : null,
                 folder.isVisible(),
                 folder.getViewCount(),
-                folder.getLikesCount(),
+                folder.getScrapCount(),
                 folder.getUser().getUserId(),
                 folder.getUser().getNickname(),
                 folder.getUser().getProfile()

--- a/src/main/java/com/Kkrap/ElasticSearch/FoldersDocument.java
+++ b/src/main/java/com/Kkrap/ElasticSearch/FoldersDocument.java
@@ -20,6 +20,7 @@ public class FoldersDocument {
     private String folderDescription;
     private String createTime;
     private Boolean visible;
+    private boolean shared;
 
     private Long viewCount;
     private Long scrapCount;
@@ -38,6 +39,7 @@ public class FoldersDocument {
                 folder.getFolderDescription(),
                 folder.getCreateTime() != null ? folder.getCreateTime().toString() : null,
                 folder.isVisible(),
+                folder.isShared(),
                 folder.getViewCount(),
                 folder.getScrapCount(),
                 folder.getUser().getUserId(),

--- a/src/main/java/com/Kkrap/Entity/Folders.java
+++ b/src/main/java/com/Kkrap/Entity/Folders.java
@@ -40,6 +40,9 @@ public class Folders {
     @Column(nullable = false, columnDefinition = "BIGINT DEFAULT 0")
     private Long viewCount = 0L;
 
+    @Column(nullable = false, columnDefinition = "BIGINT DEFAULT 0")
+    private Long likesCount = 0L;
+
     @ManyToOne
     @JoinColumn(name = "user_id", nullable = false)
     private Users user;

--- a/src/main/java/com/Kkrap/Entity/Folders.java
+++ b/src/main/java/com/Kkrap/Entity/Folders.java
@@ -43,6 +43,10 @@ public class Folders {
     @Column(nullable = false, columnDefinition = "BIGINT DEFAULT 0")
     private Long scrapCount = 0L;
 
+
+    @Column(nullable = false)
+    private boolean shared;
+
     @ManyToOne
     @JoinColumn(name = "user_id", nullable = false)
     private Users user;

--- a/src/main/java/com/Kkrap/Entity/Folders.java
+++ b/src/main/java/com/Kkrap/Entity/Folders.java
@@ -44,9 +44,11 @@ public class Folders {
     @JoinColumn(name = "user_id", nullable = false)
     private Users user;
 
-
     @OneToMany(mappedBy = "folders", cascade = CascadeType.ALL)
     private List<FoldersLinks> foldersLinks;
+
+    @OneToMany(mappedBy = "folder", cascade = CascadeType.ALL)
+    private List<FoldersPermissions> folderPermissions;
 
     public Folders(Users user, String folderName, String folderDescription, boolean visible, boolean defaultFolder) {
         this.user = user;

--- a/src/main/java/com/Kkrap/Entity/Folders.java
+++ b/src/main/java/com/Kkrap/Entity/Folders.java
@@ -41,7 +41,7 @@ public class Folders {
     private Long viewCount = 0L;
 
     @Column(nullable = false, columnDefinition = "BIGINT DEFAULT 0")
-    private Long likesCount = 0L;
+    private Long scrapCount = 0L;
 
     @ManyToOne
     @JoinColumn(name = "user_id", nullable = false)

--- a/src/main/java/com/Kkrap/Entity/FoldersPermissions.java
+++ b/src/main/java/com/Kkrap/Entity/FoldersPermissions.java
@@ -1,0 +1,57 @@
+package com.Kkrap.Entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@AllArgsConstructor
+@Table(name = "folders_permissions")
+public class FoldersPermissions {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "permissions_id")
+    private Long permissionsId;
+
+    // 폴더 소유자
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private Users owner;
+
+    // 공유되는 폴더
+    @ManyToOne
+    @JoinColumn(name = "folder_id", nullable = false)
+    private Folders folder;
+
+    // 공유 받는 대상 사용자
+    @Column(nullable = false)
+    private Long invitedUserId;
+
+    @Column(length = 255, nullable = false)
+    private String nickname;
+
+    @Column(nullable = false)
+    @CreationTimestamp
+    private LocalDateTime createTime;
+
+    private FoldersPermissions(){};
+
+    public FoldersPermissions(Users owner, Folders folders, Long invitedUserId, String nickname) {
+        this.owner = owner;
+        this.folder = folders;
+        this.invitedUserId = invitedUserId;
+        this.nickname = nickname;
+    }
+
+    public static FoldersPermissions of(Users owner, Folders folders, Users invitedUser){
+        return new FoldersPermissions(owner, folders, invitedUser.getUserId(), invitedUser.getNickname());
+
+    }
+
+
+
+}

--- a/src/main/java/com/Kkrap/Entity/Follows.java
+++ b/src/main/java/com/Kkrap/Entity/Follows.java
@@ -1,0 +1,48 @@
+package com.Kkrap.Entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@AllArgsConstructor
+@Builder
+@Table(name = "follows")
+public class Follows {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "follows_id")
+    private Long followsId;
+
+    // 팔로우를 거는 사람 (나 자신)
+    @ManyToOne
+    @JoinColumn(name = "follower_id", nullable = false)
+    private Users follower;
+
+    // 내가 팔로우하는 대상의 user_id
+    @Column(nullable = false)
+    private Long followingId;
+
+    @Column(nullable = false, length = 255)
+    private String nickname;
+
+    @Column(nullable = false, length = 2000)
+    private String profile;
+
+
+
+    private  Follows() { }
+
+    public Follows(Long userId, String nickname, String profile, Users follower) {
+        this.follower = follower;
+        this.followingId = userId;
+        this.nickname = nickname;
+        this.profile = profile;
+    }
+
+    public static Follows of(Users follower, Users following){
+        return new Follows(following.getUserId(), following.getNickname(), following.getProfile(), follower);
+    }
+}

--- a/src/main/java/com/Kkrap/Entity/Users.java
+++ b/src/main/java/com/Kkrap/Entity/Users.java
@@ -34,12 +34,15 @@ public class Users {
     private String bio;
 
 
-    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<Folders> folders;
 
 
-    @OneToMany(mappedBy = "follower", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "follower", cascade = CascadeType.ALL)
     private List<Follows> followings;
+
+    @OneToMany(mappedBy = "owner", cascade = CascadeType.ALL)
+    private List<FoldersPermissions> sharedFolders;
 
 
     private Users() { } // 외부에서 new 사용 못하게 보호

--- a/src/main/java/com/Kkrap/Entity/Users.java
+++ b/src/main/java/com/Kkrap/Entity/Users.java
@@ -38,6 +38,10 @@ public class Users {
     private List<Folders> folders;
 
 
+    @OneToMany(mappedBy = "follower", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Follows> followings;
+
+
     private Users() { } // 외부에서 new 사용 못하게 보호
 
     //정적 팩토리 메서드

--- a/src/main/java/com/Kkrap/Exception/AlreadyFollowingException.java
+++ b/src/main/java/com/Kkrap/Exception/AlreadyFollowingException.java
@@ -1,0 +1,16 @@
+package com.Kkrap.Exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AlreadyFollowingException extends RuntimeException  {
+    public AlreadyFollowingException(String message){
+        super(message);
+    }
+
+    public static AlreadyFollowingException from(String message){
+        return new AlreadyFollowingException(message);
+    }
+}

--- a/src/main/java/com/Kkrap/Exception/FoldersPermissionNotFoundException.java
+++ b/src/main/java/com/Kkrap/Exception/FoldersPermissionNotFoundException.java
@@ -1,0 +1,17 @@
+package com.Kkrap.Exception;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class FoldersPermissionNotFoundException extends RuntimeException {
+    public FoldersPermissionNotFoundException(String message){
+        super(message);
+    }
+
+    public static FoldersPermissionNotFoundException from(String message){
+        return new FoldersPermissionNotFoundException(message);
+    }
+}

--- a/src/main/java/com/Kkrap/Exception/FoldersVisibleException.java
+++ b/src/main/java/com/Kkrap/Exception/FoldersVisibleException.java
@@ -1,0 +1,13 @@
+package com.Kkrap.Exception;
+
+import lombok.Getter;
+
+@Getter
+public class FoldersVisibleException extends RuntimeException{
+    public FoldersVisibleException(String message) {
+        super(message);
+    }
+    public static FoldersVisibleException of(String message) {
+        return new FoldersVisibleException(message);
+    }
+}

--- a/src/main/java/com/Kkrap/Exception/FollowNotFoundException.java
+++ b/src/main/java/com/Kkrap/Exception/FollowNotFoundException.java
@@ -1,0 +1,17 @@
+package com.Kkrap.Exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class FollowNotFoundException extends RuntimeException {
+    public FollowNotFoundException(String message){
+        super(message);
+    }
+
+    public static FollowNotFoundException from(String message){
+        return new FollowNotFoundException(message);
+    }
+}
+

--- a/src/main/java/com/Kkrap/Exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/Kkrap/Exception/GlobalExceptionHandler.java
@@ -53,4 +53,19 @@ public class GlobalExceptionHandler {
         ErrorResponse response = ErrorResponse.from(HttpStatus.INTERNAL_SERVER_ERROR.value(), ex.getMessage());
         return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
     }
+
+    @ExceptionHandler(FollowNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleFollowNotFoundException(FollowNotFoundException ex){
+        log.error("handleFollowNotFoundException", ex);
+        ErrorResponse response = ErrorResponse.from(HttpStatus.NOT_FOUND.value(), ex.getMessage());
+        return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(AlreadyFollowingException.class)
+    public ResponseEntity<ErrorResponse> handleAlreadyFollowingException(AlreadyFollowingException ex){
+        log.error("handleAlreadyFollowingException", ex);
+        ErrorResponse response = ErrorResponse.from(HttpStatus.CONFLICT.value(), ex.getMessage());
+        return new ResponseEntity<>(response, HttpStatus.CONFLICT);
+    }
+
 }

--- a/src/main/java/com/Kkrap/Exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/Kkrap/Exception/GlobalExceptionHandler.java
@@ -68,4 +68,10 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(response, HttpStatus.CONFLICT);
     }
 
+    @ExceptionHandler(FoldersPermissionNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleFoldersPermissionNotFoundException(FoldersPermissionNotFoundException ex){
+        log.error("handleFoldersPermissionNotFoundException", ex);
+        ErrorResponse response = ErrorResponse.from(HttpStatus.NOT_FOUND.value(), ex.getMessage());
+        return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
+    }
 }

--- a/src/main/java/com/Kkrap/Exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/Kkrap/Exception/GlobalExceptionHandler.java
@@ -74,4 +74,11 @@ public class GlobalExceptionHandler {
         ErrorResponse response = ErrorResponse.from(HttpStatus.NOT_FOUND.value(), ex.getMessage());
         return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
     }
+
+    @ExceptionHandler(FoldersVisibleException.class)
+    public ResponseEntity<ErrorResponse> handleFoldersVisibleException(FoldersVisibleException ex){
+        log.error("handleFoldersVisibleException", ex);
+        ErrorResponse response = ErrorResponse.from(HttpStatus.FORBIDDEN.value(), ex.getMessage());
+        return new ResponseEntity<>(response, HttpStatus.FORBIDDEN);
+    }
 }

--- a/src/main/java/com/Kkrap/Exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/Kkrap/Exception/GlobalExceptionHandler.java
@@ -1,6 +1,6 @@
 package com.Kkrap.Exception;
 
-import com.Kkrap.ResponseDto.ErrorResponse;
+import com.Kkrap.ResponseDTO.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/Kkrap/Kafka/FolderCreateConsumer.java
+++ b/src/main/java/com/Kkrap/Kafka/FolderCreateConsumer.java
@@ -1,6 +1,8 @@
 package com.Kkrap.Kafka;
 
+import com.Kkrap.Service.FolderLink.FoldersService;
 import com.Kkrap.Service.FoldersDocument.FoldersDocumentManagerService;
+import com.Kkrap.Service.FoldersDocument.FoldersDocumentService;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -9,10 +11,12 @@ import org.springframework.stereotype.Component;
 @Component
 public class FolderCreateConsumer {
 
-    private final FoldersDocumentManagerService foldersDocumentManagerService;
+    private final FoldersDocumentService foldersDocumentService;
+    private final FoldersService foldersService;
 
-    public FolderCreateConsumer(FoldersDocumentManagerService foldersDocumentManagerService){
-        this.foldersDocumentManagerService = foldersDocumentManagerService;
+    public FolderCreateConsumer(FoldersDocumentService foldersDocumentService, FoldersService foldersService){
+        this.foldersDocumentService = foldersDocumentService;
+        this.foldersService = foldersService;
     }
 
 
@@ -27,7 +31,7 @@ public class FolderCreateConsumer {
             Long folderId = jsonNode.get("folderId").asLong();
 
             // 서비스 계층에 위임
-            foldersDocumentManagerService.indexNewFolder(folderId);
+            foldersDocumentService.indexNewFolder(foldersService.findById(folderId));
 
             System.out.println("[Kafka Consumer] Elasticsearch 색인 추가 완료: " + folderId);
 

--- a/src/main/java/com/Kkrap/Kafka/FolderCreateConsumer.java
+++ b/src/main/java/com/Kkrap/Kafka/FolderCreateConsumer.java
@@ -1,0 +1,39 @@
+package com.Kkrap.Kafka;
+
+import com.Kkrap.Service.FoldersDocument.FoldersDocumentManagerService;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FolderCreateConsumer {
+
+    private final FoldersDocumentManagerService foldersDocumentManagerService;
+
+    public FolderCreateConsumer(FoldersDocumentManagerService foldersDocumentManagerService){
+        this.foldersDocumentManagerService = foldersDocumentManagerService;
+    }
+
+
+    @KafkaListener(topics = "folder-create-topic", groupId = "folder-consumer")
+    public void consumeFolderCreate(String message) {
+        System.out.println("[Kafka Consumer] 폴더 생성 이벤트 수신: " + message);
+
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            JsonNode jsonNode = mapper.readTree(message);
+
+            Long folderId = jsonNode.get("folderId").asLong();
+
+            // 서비스 계층에 위임
+            foldersDocumentManagerService.indexNewFolder(folderId);
+
+            System.out.println("[Kafka Consumer] Elasticsearch 색인 추가 완료: " + folderId);
+
+        } catch (Exception e) {
+            System.err.println("[Kafka Consumer] 메시지 처리 실패: " + message);
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/com/Kkrap/Kafka/FolderCreateProducer.java
+++ b/src/main/java/com/Kkrap/Kafka/FolderCreateProducer.java
@@ -1,0 +1,19 @@
+package com.Kkrap.Kafka;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FolderCreateProducer {
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final String TOPIC = "folder-create-topic";
+
+    public void sendFolderCreatedEvent(String message) {
+        kafkaTemplate.send(TOPIC, message);
+        System.out.println("[Kafka Producer] 폴더 생성 이벤트 발행: " + message);
+
+    }
+}

--- a/src/main/java/com/Kkrap/Kafka/FolderViewConsumer.java
+++ b/src/main/java/com/Kkrap/Kafka/FolderViewConsumer.java
@@ -1,6 +1,7 @@
 package com.Kkrap.Kafka;
 
 import com.Kkrap.Repository.FoldersRepository;
+import com.Kkrap.Service.FoldersDocument.FoldersDocumentManagerService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
@@ -10,6 +11,7 @@ import org.springframework.stereotype.Component;
 public class FolderViewConsumer {
 
     private final FoldersRepository foldersRepository;
+    private final FoldersDocumentManagerService foldersDocumentManagerService;
 
     @KafkaListener(topics = "folder-view-topic", groupId = "folder-consumer")
     public void consumeFolderView(String message) {
@@ -18,6 +20,8 @@ public class FolderViewConsumer {
 
             foldersRepository.incrementViewCountById(folderId);
             System.out.println("[Kafka Consumer] 폴더 ID " + folderId + " → 조회수 +1");
+
+            foldersDocumentManagerService.updateFolderDocumentById(folderId);
 
         } catch (Exception e) {
             System.err.println("[Kafka Consumer] 메시지 파싱 오류: " + message);

--- a/src/main/java/com/Kkrap/Repository/FoldersDocumentRepository.java
+++ b/src/main/java/com/Kkrap/Repository/FoldersDocumentRepository.java
@@ -1,0 +1,42 @@
+package com.Kkrap.Repository;
+
+import com.Kkrap.ElasticSearch.FoldersDocument;
+import org.springframework.data.elasticsearch.annotations.Query;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface FoldersDocumentRepository extends ElasticsearchRepository<FoldersDocument, Long> {
+    List<FoldersDocument> findAll();
+
+    void deleteAll();
+
+    List<FoldersDocument> findByFolderNameContainingIgnoreCase(String keyword);
+
+    // 지난 7일 이내 + viewCount 내림차순
+    @Query("""
+    {
+      "bool": {
+        "filter": [
+          { "range": { "createTime": { "gte": "now-7d/d" } } }
+        ]
+      }
+    }
+    """)
+    List<FoldersDocument> findTop10ByCreateTimeInLastWeekOrderByViewCountDesc();
+
+    // 지난 7일 이내 + likesCount 내림차순
+    @Query("""
+    {
+      "bool": {
+        "filter": [
+          { "range": { "createTime": { "gte": "now-7d/d" } } }
+        ]
+      }
+    }
+    """)
+    List<FoldersDocument> findTop10ByCreateTimeInLastWeekOrderByLikesCountDesc();
+
+}

--- a/src/main/java/com/Kkrap/Repository/FoldersDocumentRepository.java
+++ b/src/main/java/com/Kkrap/Repository/FoldersDocumentRepository.java
@@ -27,7 +27,7 @@ public interface FoldersDocumentRepository extends ElasticsearchRepository<Folde
     """)
     List<FoldersDocument> findTop10ByCreateTimeInLastWeekOrderByViewCountDesc();
 
-    // 지난 7일 이내 + likesCount 내림차순
+    // 지난 7일 이내 + ScrapCount 내림차순
     @Query("""
     {
       "bool": {
@@ -37,6 +37,6 @@ public interface FoldersDocumentRepository extends ElasticsearchRepository<Folde
       }
     }
     """)
-    List<FoldersDocument> findTop10ByCreateTimeInLastWeekOrderByLikesCountDesc();
+    List<FoldersDocument> findTop10ByCreateTimeInLastWeekOrderByScrapCountDesc();
 
 }

--- a/src/main/java/com/Kkrap/Repository/FoldersPermissionsRepository.java
+++ b/src/main/java/com/Kkrap/Repository/FoldersPermissionsRepository.java
@@ -22,5 +22,4 @@ public interface FoldersPermissionsRepository extends JpaRepository<FoldersPermi
     List<FoldersPermissions> findByFolder(Folders folder);
 
     Optional<FoldersPermissions> findByFolderAndInvitedUserId(Folders folder, Long invitedUserId);
-
 }

--- a/src/main/java/com/Kkrap/Repository/FoldersPermissionsRepository.java
+++ b/src/main/java/com/Kkrap/Repository/FoldersPermissionsRepository.java
@@ -1,0 +1,26 @@
+package com.Kkrap.Repository;
+
+
+import com.Kkrap.Entity.Folders;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import com.Kkrap.Entity.FoldersPermissions;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface FoldersPermissionsRepository extends JpaRepository<FoldersPermissions, Long> {
+
+    // 중복 체크용: 폴더 + 초대된 사용자 ID 조합이 이미 존재하는지
+    boolean existsByFolderAndInvitedUserId(Folders folder, Long invitedUserId);
+
+    // 특정 사용자가 공유받은 폴더 목록 조회
+    List<FoldersPermissions> findByInvitedUserId(Long invitedUserId);
+
+    // 특정 폴더가 누구와 공유되었는지 조회
+    List<FoldersPermissions> findByFolder(Folders folder);
+
+    Optional<FoldersPermissions> findByFolderAndInvitedUserId(Folders folder, Long invitedUserId);
+
+}

--- a/src/main/java/com/Kkrap/Repository/FoldersRepository.java
+++ b/src/main/java/com/Kkrap/Repository/FoldersRepository.java
@@ -20,4 +20,6 @@ public interface FoldersRepository extends JpaRepository<Folders, Long> {
     @Query("UPDATE Folders f SET f.viewCount = f.viewCount + 1 WHERE f.folderId = :folderId")
     void incrementViewCountById(@Param("folderId") Long folderId);
 
+    List<Folders> findByUserUserIdAndVisibleTrue(Long userId);
+
 }

--- a/src/main/java/com/Kkrap/Repository/FollowsRepository.java
+++ b/src/main/java/com/Kkrap/Repository/FollowsRepository.java
@@ -1,0 +1,15 @@
+package com.Kkrap.Repository;
+
+import com.Kkrap.Entity.Follows;
+import com.Kkrap.Entity.Users;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface FollowsRepository extends JpaRepository<Follows, Long> {
+    boolean existsByFollowerAndFollowingId(Users follower, Long followingId); // 중복 방지용
+
+    Optional<Follows> findByFollowerAndFollowingId(Users follower, Long followingId);
+}

--- a/src/main/java/com/Kkrap/Repository/FollowsRepository.java
+++ b/src/main/java/com/Kkrap/Repository/FollowsRepository.java
@@ -5,11 +5,14 @@ import com.Kkrap.Entity.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface FollowsRepository extends JpaRepository<Follows, Long> {
-    boolean existsByFollowerAndFollowingId(Users follower, Long followingId); // 중복 방지용
+    boolean existsByFollowerAndFollowingId(Users follower, Long followingId);
 
     Optional<Follows> findByFollowerAndFollowingId(Users follower, Long followingId);
+
+    List<Follows> findByFollower(Users follower);
 }

--- a/src/main/java/com/Kkrap/Repository/UsersRepository.java
+++ b/src/main/java/com/Kkrap/Repository/UsersRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -14,6 +15,8 @@ public interface UsersRepository extends JpaRepository<Users, Long>{
     Optional<Users> findByKaKaoId(@Param("kakaoId") Long kakaoId);
 
     Optional<Users> findByNickname(String nickname);
+
+    List<Users> findByNicknameContaining(String nickname);
     
 
 }

--- a/src/main/java/com/Kkrap/RequestDTO/FoldersPermissionsCreateRequest.java
+++ b/src/main/java/com/Kkrap/RequestDTO/FoldersPermissionsCreateRequest.java
@@ -1,0 +1,16 @@
+package com.Kkrap.RequestDTO;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class FoldersPermissionsCreateRequest {
+    private Long folderId;                // 공유할 폴더 ID
+    private List<Long> invitedUserIds;   // 공유 대상 사용자 ID들
+}

--- a/src/main/java/com/Kkrap/RequestDTO/FoldersPermissionsDeleteRequest.java
+++ b/src/main/java/com/Kkrap/RequestDTO/FoldersPermissionsDeleteRequest.java
@@ -1,0 +1,15 @@
+package com.Kkrap.RequestDTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class FoldersPermissionsDeleteRequest {
+    private Long folderId;
+    private Long invitedUserId;
+}

--- a/src/main/java/com/Kkrap/RequestDTO/FollowsRequest.java
+++ b/src/main/java/com/Kkrap/RequestDTO/FollowsRequest.java
@@ -1,0 +1,14 @@
+package com.Kkrap.RequestDTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class FollowsRequest {
+    private Long followingId;
+}

--- a/src/main/java/com/Kkrap/ResponseDTO/ElasticSearchRankingResponse.java
+++ b/src/main/java/com/Kkrap/ResponseDTO/ElasticSearchRankingResponse.java
@@ -14,5 +14,5 @@ import java.util.List;
 @AllArgsConstructor
 public class ElasticSearchRankingResponse {
     private List<FoldersDocument> topViewCount;
-    private List<FoldersDocument> topLikesCount;
+    private List<FoldersDocument> topscrapCount;
 }

--- a/src/main/java/com/Kkrap/ResponseDTO/ElasticSearchRankingResponse.java
+++ b/src/main/java/com/Kkrap/ResponseDTO/ElasticSearchRankingResponse.java
@@ -1,0 +1,18 @@
+package com.Kkrap.ResponseDTO;
+
+import com.Kkrap.ElasticSearch.FoldersDocument;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ElasticSearchRankingResponse {
+    private List<FoldersDocument> topViewCount;
+    private List<FoldersDocument> topLikesCount;
+}

--- a/src/main/java/com/Kkrap/ResponseDTO/ErrorResponse.java
+++ b/src/main/java/com/Kkrap/ResponseDTO/ErrorResponse.java
@@ -1,4 +1,4 @@
-package com.Kkrap.ResponseDto;
+package com.Kkrap.ResponseDTO;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/Kkrap/ResponseDTO/FoldersLinksAllResponse.java
+++ b/src/main/java/com/Kkrap/ResponseDTO/FoldersLinksAllResponse.java
@@ -19,6 +19,7 @@ public class FoldersLinksAllResponse {
     private boolean defaultFolder;
     private Long viewCount;
     private Long scrapCount;
+    private boolean share;
 
     private LocalDateTime createTime;
     private List<LinksResponse> links;
@@ -33,11 +34,12 @@ public class FoldersLinksAllResponse {
         boolean defaultFolder = folder.isDefaultFolder();
         Long viewCount = folder.getViewCount();
         Long scrapCount = folder.getScrapCount();
+        boolean share = folder.isShared();
 
         LocalDateTime createTime = folder.getCreateTime();
         List<LinksResponse> links = linksList.stream()
                 .map(LinksResponse::new)
                 .collect(Collectors.toList());
-        return new FoldersLinksAllResponse(folderId, folderName, folderDescription, visible, defaultFolder, viewCount, scrapCount, createTime, links);
+        return new FoldersLinksAllResponse(folderId, folderName, folderDescription, visible, defaultFolder, viewCount, scrapCount, share, createTime, links);
     }
 }

--- a/src/main/java/com/Kkrap/ResponseDTO/FoldersLinksAllResponse.java
+++ b/src/main/java/com/Kkrap/ResponseDTO/FoldersLinksAllResponse.java
@@ -1,4 +1,4 @@
-package com.Kkrap.ResponseDto;
+package com.Kkrap.ResponseDTO;
 import com.Kkrap.Entity.Folders;
 import com.Kkrap.Entity.Links;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/Kkrap/ResponseDTO/FoldersLinksAllResponse.java
+++ b/src/main/java/com/Kkrap/ResponseDTO/FoldersLinksAllResponse.java
@@ -17,6 +17,9 @@ public class FoldersLinksAllResponse {
     private String folderDescription;
     private boolean visible;
     private boolean defaultFolder;
+    private Long viewCount;
+    private Long scrapCount;
+
     private LocalDateTime createTime;
     private List<LinksResponse> links;
 
@@ -28,10 +31,13 @@ public class FoldersLinksAllResponse {
         String folderDescription = folder.getFolderDescription();
         boolean visible = folder.isVisible();
         boolean defaultFolder = folder.isDefaultFolder();
+        Long viewCount = folder.getViewCount();
+        Long scrapCount = folder.getScrapCount();
+
         LocalDateTime createTime = folder.getCreateTime();
         List<LinksResponse> links = linksList.stream()
                 .map(LinksResponse::new)
                 .collect(Collectors.toList());
-        return new FoldersLinksAllResponse(folderId, folderName, folderDescription, visible, defaultFolder ,createTime, links);
+        return new FoldersLinksAllResponse(folderId, folderName, folderDescription, visible, defaultFolder, viewCount, scrapCount, createTime, links);
     }
 }

--- a/src/main/java/com/Kkrap/ResponseDTO/FoldersResponse.java
+++ b/src/main/java/com/Kkrap/ResponseDTO/FoldersResponse.java
@@ -1,4 +1,4 @@
-package com.Kkrap.ResponseDto;
+package com.Kkrap.ResponseDTO;
 
 
 import com.Kkrap.Entity.Folders;

--- a/src/main/java/com/Kkrap/ResponseDTO/FollowsResponse.java
+++ b/src/main/java/com/Kkrap/ResponseDTO/FollowsResponse.java
@@ -1,4 +1,4 @@
-package com.Kkrap.ResponseDto;
+package com.Kkrap.ResponseDTO;
 
 
 import com.Kkrap.Entity.Follows;

--- a/src/main/java/com/Kkrap/ResponseDTO/LinksCreateResponse.java
+++ b/src/main/java/com/Kkrap/ResponseDTO/LinksCreateResponse.java
@@ -1,12 +1,8 @@
-package com.Kkrap.ResponseDto;
+package com.Kkrap.ResponseDTO;
 
 import com.Kkrap.Entity.Links;
-import com.Kkrap.RequestDTO.LinksCreateRequest;
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.persistence.Column;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.time.LocalDateTime;

--- a/src/main/java/com/Kkrap/ResponseDTO/LinksResponse.java
+++ b/src/main/java/com/Kkrap/ResponseDTO/LinksResponse.java
@@ -1,4 +1,4 @@
-package com.Kkrap.ResponseDto;
+package com.Kkrap.ResponseDTO;
 
 import com.Kkrap.Entity.Links;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/Kkrap/ResponseDTO/MessageResponse.java
+++ b/src/main/java/com/Kkrap/ResponseDTO/MessageResponse.java
@@ -1,4 +1,4 @@
-package com.Kkrap.ResponseDto;
+package com.Kkrap.ResponseDTO;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/Kkrap/ResponseDTO/UserFoldersWithSharedResponse.java
+++ b/src/main/java/com/Kkrap/ResponseDTO/UserFoldersWithSharedResponse.java
@@ -1,0 +1,24 @@
+package com.Kkrap.ResponseDTO;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class UserFoldersWithSharedResponse {
+    private List<FoldersLinksAllResponse> ownFolders;
+    private List<FoldersLinksAllResponse> sharedFolders;
+
+
+    private UserFoldersWithSharedResponse() {}
+
+    public static UserFoldersWithSharedResponse of(List<FoldersLinksAllResponse> ownFolders, List<FoldersLinksAllResponse> sharedFolders){
+        return new UserFoldersWithSharedResponse(ownFolders, sharedFolders);
+    }
+
+}

--- a/src/main/java/com/Kkrap/ResponseDTO/UsersProfileResponse.java
+++ b/src/main/java/com/Kkrap/ResponseDTO/UsersProfileResponse.java
@@ -1,10 +1,9 @@
-package com.Kkrap.ResponseDto;
+package com.Kkrap.ResponseDTO;
 
 import com.Kkrap.Entity.Users;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.catalina.User;
 
 @Getter
 @Setter

--- a/src/main/java/com/Kkrap/ResponseDto/FollowsResponse.java
+++ b/src/main/java/com/Kkrap/ResponseDto/FollowsResponse.java
@@ -1,0 +1,25 @@
+package com.Kkrap.ResponseDto;
+
+
+import com.Kkrap.Entity.Follows;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class FollowsResponse {
+    private Long followsId;
+
+    // 팔로우를 거는 사람 (나 자신)
+    private Long followingId;
+    private String nickname;
+    private String profile;
+
+    private FollowsResponse(){}
+
+    public static FollowsResponse of(Follows follows){
+        return new FollowsResponse(follows.getFollowsId(), follows.getFollowingId(), follows.getNickname(), follows.getProfile());
+    }
+}

--- a/src/main/java/com/Kkrap/Service/AuthService.java
+++ b/src/main/java/com/Kkrap/Service/AuthService.java
@@ -1,19 +1,13 @@
 package com.Kkrap.Service;
 
-import com.Kkrap.Entity.Users;
 import com.Kkrap.Exception.NotValidTokenException;
-import com.Kkrap.Repository.UsersRepository;
-import com.Kkrap.RequestDTO.FoldersCreateRequest;
 import com.Kkrap.RequestDTO.KaKaoTokenRequest;
-import com.Kkrap.RequestDTO.UsersCreateRequest;
-import com.Kkrap.ResponseDto.UsersProfileResponse;
-import com.Kkrap.Service.FolderLink.FoldersService;
+import com.Kkrap.ResponseDTO.UsersProfileResponse;
 import com.Kkrap.Service.SocialLogin.RestTemplateKakaoProvider;
 import org.springframework.stereotype.Service;
 import org.springframework.web.bind.annotation.RequestBody;
 
 import java.util.Map;
-import java.util.Optional;
 
 @Service
 public class AuthService {

--- a/src/main/java/com/Kkrap/Service/FolderLink/FoldersManagerService.java
+++ b/src/main/java/com/Kkrap/Service/FolderLink/FoldersManagerService.java
@@ -10,7 +10,9 @@ import com.Kkrap.RequestDTO.FoldersDeleteRequest;
 import com.Kkrap.RequestDTO.FoldersUpdateRequest;
 import com.Kkrap.ResponseDTO.FoldersLinksAllResponse;
 import com.Kkrap.ResponseDTO.FoldersResponse;
+import com.Kkrap.Service.FoldersDocument.FoldersDocumentService;
 import com.Kkrap.Service.Users.UsersService;
+import jakarta.transaction.Transactional;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -33,15 +35,20 @@ public class FoldersManagerService {
 
     private final FolderCreateProducer folderCreateProducer;
 
+    private final FoldersDocumentService foldersDocumentService;
+
     public FoldersManagerService(FoldersService foldersService, UsersService usersService, FoldersLinksService foldersLinksService,
                                  LinksService linksService, StringRedisTemplate redisTemplate,
-                                 FolderCreateProducer folderCreateProducer) {
+                                 FolderCreateProducer folderCreateProducer,
+                                 FoldersDocumentService foldersDocumentService
+                                 ) {
         this.foldersService = foldersService;
         this.usersService = usersService;
         this.foldersLinksService = foldersLinksService;
         this.linksService = linksService;
         this.redisTemplate = redisTemplate;
         this.folderCreateProducer = folderCreateProducer;
+        this.foldersDocumentService = foldersDocumentService;
     }
 
 
@@ -108,6 +115,7 @@ public class FoldersManagerService {
     }
 
     //Delete - 폴더 삭제
+    @Transactional
     public ResponseEntity<FoldersResponse> deleteUserFolder(Long userId, FoldersDeleteRequest foldersDeleteRequest)
     {
         //사용자 체크
@@ -129,13 +137,31 @@ public class FoldersManagerService {
         // folders 삭제
         foldersService.deleteById(folderId);
 
+        //색인 업데이트
+        foldersDocumentService.deleteFolderDocument(folders);
+
         //응답 데이터를 삭제된 링크들까지 포함 시켜서 해주어야함 - 정환행님한테 물어보기
         return ResponseEntity.ok(FoldersResponse.from(folders, userId));
     }
 
+    @Transactional
     public ResponseEntity<FoldersResponse> updateFolderMetadata(FoldersUpdateRequest request){
         Users users = usersService.findById(request.getUserId());
-        return foldersService.updateFolderMetadata(request.getFolderId(), users.getUserId(), request.getFolderName(), request.getFolderDescription(), request.isVisible());
+        Folders folders = foldersService.findById(request.getFolderId());
+
+        foldersService.isOwnedByService(folders, users.getUserId());
+        folders.setFolderName(request.getFolderName());
+        folders.setFolderDescription(request.getFolderDescription());
+        folders.setVisible(request.isVisible());
+        foldersService.save(folders);
+
+        if (folders.isVisible()) {
+            foldersDocumentService.indexNewFolder(folders);
+        } else {
+            foldersDocumentService.deleteFolderDocument(folders);
+        }
+
+        return ResponseEntity.ok(FoldersResponse.from(folders, users.getUserId()));
     }
 
 

--- a/src/main/java/com/Kkrap/Service/FolderLink/FoldersManagerService.java
+++ b/src/main/java/com/Kkrap/Service/FolderLink/FoldersManagerService.java
@@ -4,17 +4,16 @@ import com.Kkrap.Entity.Folders;
 import com.Kkrap.Entity.FoldersLinks;
 import com.Kkrap.Entity.Links;
 import com.Kkrap.Entity.Users;
+import com.Kkrap.Kafka.FolderCreateProducer;
 import com.Kkrap.RequestDTO.FoldersCreateRequest;
 import com.Kkrap.RequestDTO.FoldersDeleteRequest;
 import com.Kkrap.RequestDTO.FoldersUpdateRequest;
-import com.Kkrap.ResponseDto.FoldersLinksAllResponse;
-import com.Kkrap.ResponseDto.FoldersResponse;
+import com.Kkrap.ResponseDTO.FoldersLinksAllResponse;
+import com.Kkrap.ResponseDTO.FoldersResponse;
 import com.Kkrap.Service.Users.UsersService;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
 
 import java.time.Duration;
 import java.util.List;
@@ -32,13 +31,17 @@ public class FoldersManagerService {
 
     private final StringRedisTemplate redisTemplate;
 
+    private final FolderCreateProducer folderCreateProducer;
+
     public FoldersManagerService(FoldersService foldersService, UsersService usersService, FoldersLinksService foldersLinksService,
-                                 LinksService linksService, StringRedisTemplate redisTemplate) {
+                                 LinksService linksService, StringRedisTemplate redisTemplate,
+                                 FolderCreateProducer folderCreateProducer) {
         this.foldersService = foldersService;
         this.usersService = usersService;
         this.foldersLinksService = foldersLinksService;
         this.linksService = linksService;
         this.redisTemplate = redisTemplate;
+        this.folderCreateProducer = folderCreateProducer;
     }
 
 
@@ -93,6 +96,14 @@ public class FoldersManagerService {
     {
         Users users = usersService.findById(userId);
         Folders folders = foldersService.save(foldersCreateRequest, users);
+        if (Boolean.TRUE.equals(folders.isVisible())) {
+            String eventPayload = String.format(
+                    "{\"folderId\": %d}",
+                    folders.getFolderId()
+            );
+            folderCreateProducer.sendFolderCreatedEvent(eventPayload);
+        }
+
         return ResponseEntity.ok(FoldersResponse.from(folders, users.getUserId()));
     }
 

--- a/src/main/java/com/Kkrap/Service/FolderLink/FoldersManagerService.java
+++ b/src/main/java/com/Kkrap/Service/FolderLink/FoldersManagerService.java
@@ -1,25 +1,27 @@
 package com.Kkrap.Service.FolderLink;
 
-import com.Kkrap.Entity.Folders;
-import com.Kkrap.Entity.FoldersLinks;
-import com.Kkrap.Entity.Links;
-import com.Kkrap.Entity.Users;
+import com.Kkrap.Entity.*;
 import com.Kkrap.Kafka.FolderCreateProducer;
 import com.Kkrap.RequestDTO.FoldersCreateRequest;
 import com.Kkrap.RequestDTO.FoldersDeleteRequest;
 import com.Kkrap.RequestDTO.FoldersUpdateRequest;
 import com.Kkrap.ResponseDTO.FoldersLinksAllResponse;
 import com.Kkrap.ResponseDTO.FoldersResponse;
+import com.Kkrap.ResponseDTO.UserFoldersWithSharedResponse;
 import com.Kkrap.Service.FoldersDocument.FoldersDocumentService;
+import com.Kkrap.Service.FollowsFoldersPermission.FoldersPermissionsService;
 import com.Kkrap.Service.Users.UsersService;
-import jakarta.transaction.Transactional;
+
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Service
 public class FoldersManagerService {
@@ -37,10 +39,13 @@ public class FoldersManagerService {
 
     private final FoldersDocumentService foldersDocumentService;
 
+    private final FoldersPermissionsService foldersPermissionsService;
+
     public FoldersManagerService(FoldersService foldersService, UsersService usersService, FoldersLinksService foldersLinksService,
                                  LinksService linksService, StringRedisTemplate redisTemplate,
                                  FolderCreateProducer folderCreateProducer,
-                                 FoldersDocumentService foldersDocumentService
+                                 FoldersDocumentService foldersDocumentService,
+                                 FoldersPermissionsService foldersPermissionsService
                                  ) {
         this.foldersService = foldersService;
         this.usersService = usersService;
@@ -49,43 +54,167 @@ public class FoldersManagerService {
         this.redisTemplate = redisTemplate;
         this.folderCreateProducer = folderCreateProducer;
         this.foldersDocumentService = foldersDocumentService;
+        this.foldersPermissionsService = foldersPermissionsService;
     }
 
 
-    public ResponseEntity<List<FoldersLinksAllResponse>> getUserAllFoldersWithLinks(Long userId){
+    @Transactional(readOnly = true)
+    public ResponseEntity<UserFoldersWithSharedResponse> getUserAllFoldersWithLinks(Long userId){
         usersService.findById(userId);
-        List<Folders> folders = foldersService.findByUserUserId(userId);
-        List<FoldersLinksAllResponse> responseList = folders.stream().map(folder -> {
-            List<FoldersLinks> folderLinksList = foldersLinksService.findByFolders(folder);
-            List<Links> linksList = linksService.selectLinksByCreateTime(folderLinksList);
-            return FoldersLinksAllResponse.of(folder, linksList);
-        }).collect(Collectors.toList());
-        return ResponseEntity.ok(responseList);
+        List<Folders> allMyFolders = foldersService.findByUserUserId(userId);
+
+        // shared 컬럼으로 분리
+        List<Folders> ownFolders = allMyFolders.stream()
+                .filter(folder -> !folder.isShared())
+                .collect(Collectors.toList());
+
+        List<Folders> mySharedFolders = allMyFolders.stream()
+                .filter(Folders::isShared)
+                .collect(Collectors.toList());
+
+        // 공유받은 폴더 (권한 테이블 기준)
+        List<FoldersPermissions> sharedPermissions = foldersPermissionsService.findByInvitedUserId(userId);
+        List<Folders> invitedSharedFolders = sharedPermissions.stream()
+                .map(permission -> foldersService.findById(permission.getFolder().getFolderId()))
+                .collect(Collectors.toList());
+
+        // 공유 폴더 합치기
+        List<Folders> allSharedFolders = Stream.concat(
+                mySharedFolders.stream(),  // 내가 만든 공유 폴더
+                invitedSharedFolders.stream()  // 내가 초대받은 공유 폴더
+        ).toList();
+
+        //변환
+        List<FoldersLinksAllResponse> ownFolderResponses = ownFolders.stream()
+                .map(folder -> {
+                    List<FoldersLinks> folderLinksList = foldersLinksService.findByFolders(folder);
+                    List<Links> linksList = linksService.selectLinksByCreateTime(folderLinksList);
+                    return FoldersLinksAllResponse.of(folder, linksList);
+                })
+                .collect(Collectors.toList());
+
+        List<FoldersLinksAllResponse> sharedFolderResponses = allSharedFolders.stream()
+                .map(folder -> {
+                    List<FoldersLinks> folderLinksList = foldersLinksService.findByFolders(folder);
+                    List<Links> linksList = linksService.selectLinksByCreateTime(folderLinksList);
+                    return FoldersLinksAllResponse.of(folder, linksList);
+                })
+                .collect(Collectors.toList());
+
+        UserFoldersWithSharedResponse response = UserFoldersWithSharedResponse.of(ownFolderResponses, sharedFolderResponses);
+        return ResponseEntity.ok(response);
     }
 
-    public ResponseEntity<List<FoldersLinksAllResponse>> getUserAllFoldersWithTop4Links(Long userId){
+    //상대방 모든 거 조회할 때
+    @Transactional(readOnly = true)
+    public ResponseEntity<UserFoldersWithSharedResponse> getAllFoldersWithTop4LinksByUser(Long userId) {
         usersService.findById(userId);
-        List<Folders> folders = foldersService.findByUserUserId(userId);
-        List<FoldersLinksAllResponse> responseList = folders.stream().map(folder -> {
-            List<FoldersLinks> folderLinksList = foldersLinksService.findByFolders(folder);
-            List<Links> linksList = linksService.selectTop4LinksByCreateTime(folderLinksList);
-            return FoldersLinksAllResponse.of(folder, linksList);
-        }).collect(Collectors.toList());
-        return ResponseEntity.ok(responseList);
+        List<Folders> allMyFolders = foldersService.findByUserUserId(userId);
+
+        // visible = true 필터
+        List<Folders> ownFolders = allMyFolders.stream()
+                .filter(folder -> !folder.isShared() && folder.isVisible())
+                .collect(Collectors.toList());
+
+        List<Folders> mySharedFolders = allMyFolders.stream()
+                .filter(folder -> folder.isShared() && folder.isVisible())
+                .collect(Collectors.toList());
+
+        // 초대받은 공유 폴더
+        List<FoldersPermissions> sharedPermissions = foldersPermissionsService.findByInvitedUserId(userId);
+        List<Folders> invitedSharedFolders = sharedPermissions.stream()
+                .map(permission -> foldersService.findById(permission.getFolder().getFolderId()))
+                .filter(Folders::isVisible)  // 초대받은 것도 visible만
+                .collect(Collectors.toList());
+
+        // 모든 공유 폴더
+        List<Folders> allSharedFolders = Stream.concat(
+                mySharedFolders.stream(),
+                invitedSharedFolders.stream()
+        ).toList();
+
+        List<FoldersLinksAllResponse> ownFolderResponses = ownFolders.stream()
+                .map(folder -> {
+                    List<FoldersLinks> folderLinksList = foldersLinksService.findByFolders(folder);
+                    List<Links> linksList = linksService.selectTop4LinksByCreateTime(folderLinksList);
+                    return FoldersLinksAllResponse.of(folder, linksList);
+                })
+                .collect(Collectors.toList());
+
+        List<FoldersLinksAllResponse> sharedFolderResponses = allSharedFolders.stream()
+                .map(folder -> {
+                    List<FoldersLinks> folderLinksList = foldersLinksService.findByFolders(folder);
+                    List<Links> linksList = linksService.selectTop4LinksByCreateTime(folderLinksList);
+                    return FoldersLinksAllResponse.of(folder, linksList);
+                })
+                .collect(Collectors.toList());
+
+        UserFoldersWithSharedResponse response = UserFoldersWithSharedResponse.of(ownFolderResponses, sharedFolderResponses);
+        return ResponseEntity.ok(response);
+    }
+
+
+    public ResponseEntity<UserFoldersWithSharedResponse> getMeAllFoldersWithTop4Links(Long userId){
+        usersService.findById(userId);
+        List<Folders> allMyFolders = foldersService.findByUserUserId(userId);
+
+        // shared 컬럼으로 분리
+        List<Folders> ownFolders = allMyFolders.stream()
+                .filter(folder -> !folder.isShared())
+                .collect(Collectors.toList());
+
+        List<Folders> mySharedFolders = allMyFolders.stream()
+                .filter(Folders::isShared)
+                .collect(Collectors.toList());
+
+        // 공유받은 폴더 (권한 테이블 기준)
+        List<FoldersPermissions> sharedPermissions = foldersPermissionsService.findByInvitedUserId(userId);
+        List<Folders> invitedSharedFolders = sharedPermissions.stream()
+                .map(permission -> foldersService.findById(permission.getFolder().getFolderId()))
+                .collect(Collectors.toList());
+
+        // 공유 폴더 합치기
+        List<Folders> allSharedFolders = Stream.concat(
+                mySharedFolders.stream(),  // 내가 만든 공유 폴더
+                invitedSharedFolders.stream()  // 내가 초대받은 공유 폴더
+        ).toList();
+
+        //변환
+        List<FoldersLinksAllResponse> ownFolderResponses = ownFolders.stream()
+                .map(folder -> {
+                    List<FoldersLinks> folderLinksList = foldersLinksService.findByFolders(folder);
+                    List<Links> linksList = linksService.selectTop4LinksByCreateTime(folderLinksList);
+                    return FoldersLinksAllResponse.of(folder, linksList);
+                })
+                .collect(Collectors.toList());
+
+        List<FoldersLinksAllResponse> sharedFolderResponses = allSharedFolders.stream()
+                .map(folder -> {
+                    List<FoldersLinks> folderLinksList = foldersLinksService.findByFolders(folder);
+                    List<Links> linksList = linksService.selectTop4LinksByCreateTime(folderLinksList);
+                    return FoldersLinksAllResponse.of(folder, linksList);
+                })
+                .collect(Collectors.toList());
+
+        UserFoldersWithSharedResponse response = UserFoldersWithSharedResponse.of(ownFolderResponses, sharedFolderResponses);
+        return ResponseEntity.ok(response);
     }
 
     //조회수 -> Redis -> Kafka
-    public ResponseEntity<FoldersLinksAllResponse> getOneFolderWithLinksByUser(Long userId, Long folderId){
+    @Transactional(readOnly = true)
+    public ResponseEntity<FoldersLinksAllResponse> getOneFolderWithLinksByUser(Long userId, Long folderId) {
         Folders folder = foldersService.findById(folderId);
-        // Redis에 조회 기록 저장 (userId와 folderId 기준으로 TTL 5분)
+        foldersService.isVisibleBy(folder);
+
         String redisKey = "view:" + userId + ":" + folderId;
         redisTemplate.opsForValue().set(redisKey, String.valueOf(folderId), Duration.ofMinutes(5));
 
-        //해당 폴더의 FoldersLinks 조회
         List<FoldersLinks> folderLinksList = foldersLinksService.findByFolders(folder);
         List<Links> linksList = linksService.selectLinksByCreateTime(folderLinksList);
+
         return ResponseEntity.ok(FoldersLinksAllResponse.of(folder, linksList));
     }
+
 
     public ResponseEntity<FoldersLinksAllResponse> getMyOneFolderWithLinks(Long folderId){
         //폴더가 있는지 검사

--- a/src/main/java/com/Kkrap/Service/FolderLink/FoldersService.java
+++ b/src/main/java/com/Kkrap/Service/FolderLink/FoldersService.java
@@ -5,7 +5,7 @@ import com.Kkrap.Entity.Users;
 import com.Kkrap.Exception.FoldersNotFoundException;
 import com.Kkrap.Repository.FoldersRepository;
 import com.Kkrap.RequestDTO.FoldersCreateRequest;
-import com.Kkrap.ResponseDto.FoldersResponse;
+import com.Kkrap.ResponseDTO.FoldersResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
@@ -68,6 +68,11 @@ public class FoldersService {
             throw FoldersNotFoundException.of("폴더가 존재하지 않습니다.");
         }
     }
+
+    public List<Folders> findAll(){
+        return foldersRepository.findAll();
+    }
+
 
 
 

--- a/src/main/java/com/Kkrap/Service/FolderLink/FoldersService.java
+++ b/src/main/java/com/Kkrap/Service/FolderLink/FoldersService.java
@@ -50,19 +50,6 @@ public class FoldersService {
         foldersRepository.deleteById(folderId);
     }
 
-    //폴더 수정
-    public ResponseEntity<FoldersResponse> updateFolderMetadata(Long folderId, Long userId, String folderName, String folderDescription, boolean visible){
-        Folders folders = findById(folderId);
-        if (!folders.isOwnedBy(userId)) {
-            throw FoldersNotFoundException.of("폴더가 존재하지 않습니다.");
-        }
-        folders.setFolderName(folderName);
-        folders.setFolderDescription(folderDescription);
-        folders.setVisible(visible);
-        save(folders);
-        return ResponseEntity.ok(FoldersResponse.from(folders, userId));
-    }
-
     public void isOwnedByService(Folders folders ,Long userId) {
         if (!folders.isOwnedBy(userId)) {
             throw FoldersNotFoundException.of("폴더가 존재하지 않습니다.");
@@ -72,6 +59,12 @@ public class FoldersService {
     public List<Folders> findAll(){
         return foldersRepository.findAll();
     }
+
+    public List<Folders> findByUserIdAndVisibleTrue(Long userId) {
+        return foldersRepository.findByUserUserIdAndVisibleTrue(userId);
+    }
+
+
 
 
 

--- a/src/main/java/com/Kkrap/Service/FolderLink/FoldersService.java
+++ b/src/main/java/com/Kkrap/Service/FolderLink/FoldersService.java
@@ -63,6 +63,12 @@ public class FoldersService {
         return ResponseEntity.ok(FoldersResponse.from(folders, userId));
     }
 
+    public void isOwnedByService(Folders folders ,Long userId) {
+        if (!folders.isOwnedBy(userId)) {
+            throw FoldersNotFoundException.of("폴더가 존재하지 않습니다.");
+        }
+    }
+
 
 
 }

--- a/src/main/java/com/Kkrap/Service/FolderLink/FoldersService.java
+++ b/src/main/java/com/Kkrap/Service/FolderLink/FoldersService.java
@@ -3,6 +3,7 @@ package com.Kkrap.Service.FolderLink;
 import com.Kkrap.Entity.Folders;
 import com.Kkrap.Entity.Users;
 import com.Kkrap.Exception.FoldersNotFoundException;
+import com.Kkrap.Exception.FoldersVisibleException;
 import com.Kkrap.Repository.FoldersRepository;
 import com.Kkrap.RequestDTO.FoldersCreateRequest;
 import com.Kkrap.ResponseDTO.FoldersResponse;
@@ -63,6 +64,13 @@ public class FoldersService {
     public List<Folders> findByUserIdAndVisibleTrue(Long userId) {
         return foldersRepository.findByUserUserIdAndVisibleTrue(userId);
     }
+
+    public void isVisibleBy(Folders folders){
+        if (!folders.isVisible()){
+            throw FoldersVisibleException.of("공개 권한이 없는 폴더입니다.");
+        }
+    }
+
 
 
 

--- a/src/main/java/com/Kkrap/Service/FolderLink/LinksManagerService.java
+++ b/src/main/java/com/Kkrap/Service/FolderLink/LinksManagerService.java
@@ -5,7 +5,7 @@ import com.Kkrap.Entity.FoldersLinks;
 import com.Kkrap.Entity.Links;
 import com.Kkrap.RequestDTO.LinksCreateRequest;
 import com.Kkrap.RequestDTO.LinksDeleteRequest;
-import com.Kkrap.ResponseDto.LinksCreateResponse;
+import com.Kkrap.ResponseDTO.LinksCreateResponse;
 import com.Kkrap.Service.Users.UsersService;
 import com.Kkrap.Util.LinkMetadataExtractor;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/Kkrap/Service/FoldersDocument/FoldersDocumentManagerService.java
+++ b/src/main/java/com/Kkrap/Service/FoldersDocument/FoldersDocumentManagerService.java
@@ -1,0 +1,70 @@
+package com.Kkrap.Service.FoldersDocument;
+
+import com.Kkrap.ElasticSearch.FoldersDocument;
+import com.Kkrap.Entity.Folders;
+import com.Kkrap.Repository.FoldersDocumentRepository;
+import com.Kkrap.ResponseDTO.ElasticSearchRankingResponse;
+import com.Kkrap.Service.FolderLink.FoldersService;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class FoldersDocumentManagerService {
+    private final FoldersDocumentService foldersDocumentService;
+
+    private final FoldersService foldersService;
+
+    public FoldersDocumentManagerService(FoldersDocumentService foldersDocumentService, FoldersService foldersService){
+        this.foldersDocumentService = foldersDocumentService;
+        this.foldersService = foldersService;
+    }
+
+
+    //이거는 우리 백엔드에서 사용할 DB 전체를 색인
+    public FoldersDocument indexNewFolder(Folders folder) {
+        FoldersDocument doc = FoldersDocument.from(folder);
+        return foldersDocumentService.save(doc);
+    }
+
+    //폴더 생성 후 -> 카프카에서 이걸 실행
+    public void indexNewFolder(Long folderId) {
+        Folders folders = foldersService.findById(folderId);
+        FoldersDocument doc = FoldersDocument.from(folders);
+        foldersDocumentService.save(doc);
+    }
+
+    public List<FoldersDocument> getAllDocuments() {
+        return foldersDocumentService.findAll();
+    }
+
+    public void migrateAllFoldersToElasticsearch() {
+
+        List<Folders> allFolders = foldersService.findAll();
+
+        allFolders.stream()
+                .filter(folder -> folder.isVisible())
+                .forEach(this::indexNewFolder);
+
+        System.out.println("visible = false 인 모든 폴더가 Elasticsearch에 색인되었습니다!");
+    }
+
+
+    public void deleteAllDocuments() {
+        foldersDocumentService.deleteAll();
+    }
+
+    public List<FoldersDocument> searchFolders(String keyword) {
+        return foldersDocumentService.searchByName(keyword);
+    }
+
+    public ElasticSearchRankingResponse getWeeklyRankings() {
+        List<FoldersDocument> topViewCount = foldersDocumentService.getTop10ViewCountLastWeek();
+        List<FoldersDocument> topLikesCount = foldersDocumentService.getTop10LikesCountLastWeek();
+
+        return new ElasticSearchRankingResponse(topViewCount, topLikesCount);
+    }
+
+
+
+}

--- a/src/main/java/com/Kkrap/Service/FoldersDocument/FoldersDocumentManagerService.java
+++ b/src/main/java/com/Kkrap/Service/FoldersDocument/FoldersDocumentManagerService.java
@@ -60,9 +60,9 @@ public class FoldersDocumentManagerService {
 
     public ElasticSearchRankingResponse getWeeklyRankings() {
         List<FoldersDocument> topViewCount = foldersDocumentService.getTop10ViewCountLastWeek();
-        List<FoldersDocument> topLikesCount = foldersDocumentService.getTop10LikesCountLastWeek();
+        List<FoldersDocument> topScrapCount = foldersDocumentService.getTop10ScrapCountLastWeek();
 
-        return new ElasticSearchRankingResponse(topViewCount, topLikesCount);
+        return new ElasticSearchRankingResponse(topViewCount, topScrapCount);
     }
 
 

--- a/src/main/java/com/Kkrap/Service/FoldersDocument/FoldersDocumentManagerService.java
+++ b/src/main/java/com/Kkrap/Service/FoldersDocument/FoldersDocumentManagerService.java
@@ -2,10 +2,12 @@ package com.Kkrap.Service.FoldersDocument;
 
 import com.Kkrap.ElasticSearch.FoldersDocument;
 import com.Kkrap.Entity.Folders;
+import com.Kkrap.Entity.Users;
 import com.Kkrap.Repository.FoldersDocumentRepository;
 import com.Kkrap.ResponseDTO.ElasticSearchRankingResponse;
 import com.Kkrap.Service.FolderLink.FoldersService;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -21,19 +23,6 @@ public class FoldersDocumentManagerService {
     }
 
 
-    //이거는 우리 백엔드에서 사용할 DB 전체를 색인
-    public FoldersDocument indexNewFolder(Folders folder) {
-        FoldersDocument doc = FoldersDocument.from(folder);
-        return foldersDocumentService.save(doc);
-    }
-
-    //폴더 생성 후 -> 카프카에서 이걸 실행
-    public void indexNewFolder(Long folderId) {
-        Folders folders = foldersService.findById(folderId);
-        FoldersDocument doc = FoldersDocument.from(folders);
-        foldersDocumentService.save(doc);
-    }
-
     public List<FoldersDocument> getAllDocuments() {
         return foldersDocumentService.findAll();
     }
@@ -44,7 +33,7 @@ public class FoldersDocumentManagerService {
 
         allFolders.stream()
                 .filter(folder -> folder.isVisible())
-                .forEach(this::indexNewFolder);
+                .forEach(folder -> foldersDocumentService.indexNewFolder(folder));
 
         System.out.println("visible = false 인 모든 폴더가 Elasticsearch에 색인되었습니다!");
     }
@@ -65,6 +54,10 @@ public class FoldersDocumentManagerService {
         return new ElasticSearchRankingResponse(topViewCount, topScrapCount);
     }
 
-
-
+    //조회수 업데이트 후 색인 업데이트
+    @Transactional(readOnly = true)
+    public void updateFolderDocumentById(Long folderId) {
+        Folders folder = foldersService.findById(folderId);
+        foldersDocumentService.indexNewFolder(folder);
+    }
 }

--- a/src/main/java/com/Kkrap/Service/FoldersDocument/FoldersDocumentService.java
+++ b/src/main/java/com/Kkrap/Service/FoldersDocument/FoldersDocumentService.java
@@ -1,0 +1,54 @@
+package com.Kkrap.Service.FoldersDocument;
+
+import com.Kkrap.ElasticSearch.FoldersDocument;
+import com.Kkrap.Repository.FoldersDocumentRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Comparator;
+import java.util.stream.Collectors;
+
+@Service
+public class FoldersDocumentService {
+    private final FoldersDocumentRepository foldersDocumentRepository;
+
+    public FoldersDocumentService(FoldersDocumentRepository foldersDocumentRepository){
+        this.foldersDocumentRepository = foldersDocumentRepository;
+    }
+
+    public FoldersDocument save(FoldersDocument doc) {
+        return foldersDocumentRepository.save(doc);
+    }
+
+    public List<FoldersDocument> findAll() {
+        return foldersDocumentRepository.findAll();
+    }
+    public void deleteAll() {
+        foldersDocumentRepository.deleteAll();
+    }
+
+    public List<FoldersDocument> searchByName(String keyword) {
+        return foldersDocumentRepository.findByFolderNameContainingIgnoreCase(keyword);
+    }
+
+
+    public List<FoldersDocument> getTop10ViewCountLastWeek() {
+        List<FoldersDocument> docs = foldersDocumentRepository.findTop10ByCreateTimeInLastWeekOrderByViewCountDesc();
+        // 혹시 정렬이 부족하면 자바에서 한 번 더 안전하게
+        return docs.stream()
+                .sorted(Comparator.comparingLong(FoldersDocument::getViewCount).reversed())
+                .limit(10)
+                .collect(Collectors.toList());
+    }
+
+    public List<FoldersDocument> getTop10LikesCountLastWeek() {
+        List<FoldersDocument> docs = foldersDocumentRepository.findTop10ByCreateTimeInLastWeekOrderByLikesCountDesc();
+        return docs.stream()
+                .sorted(Comparator.comparingLong(FoldersDocument::getLikesCount).reversed())
+                .limit(10)
+                .collect(Collectors.toList());
+    }
+
+
+
+}

--- a/src/main/java/com/Kkrap/Service/FoldersDocument/FoldersDocumentService.java
+++ b/src/main/java/com/Kkrap/Service/FoldersDocument/FoldersDocumentService.java
@@ -1,8 +1,11 @@
 package com.Kkrap.Service.FoldersDocument;
 
 import com.Kkrap.ElasticSearch.FoldersDocument;
+import com.Kkrap.Entity.Folders;
+import com.Kkrap.Entity.Users;
 import com.Kkrap.Repository.FoldersDocumentRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Comparator;
@@ -15,6 +18,29 @@ public class FoldersDocumentService {
     public FoldersDocumentService(FoldersDocumentRepository foldersDocumentRepository){
         this.foldersDocumentRepository = foldersDocumentRepository;
     }
+
+    //우리 백엔드에서 사용할 DB 전체를 색인
+    //폴더 생성 후 -> 카프카에서 이걸 실행
+    public void indexNewFolder(Folders folder) {
+        FoldersDocument doc = FoldersDocument.from(folder);
+        save(doc);
+    }
+
+    //색인 삭제
+    public void deleteFolderDocument(Folders folder) {
+        deleteById(folder.getFolderId());
+    }
+
+    @Transactional
+    public void updateUserInfoInFolderDocuments(Users users, List<Folders> userFolders) {
+        // 색인 업데이트
+        userFolders.forEach(folder -> {
+            indexNewFolder(folder);
+        });
+
+        System.out.println("[Elasticsearch] 사용자 정보 변경으로 색인 업데이트 완료: userId=" + users.getUserId());
+    }
+
 
     public FoldersDocument save(FoldersDocument doc) {
         return foldersDocumentRepository.save(doc);
@@ -29,6 +55,10 @@ public class FoldersDocumentService {
 
     public List<FoldersDocument> searchByName(String keyword) {
         return foldersDocumentRepository.findByFolderNameContainingIgnoreCase(keyword);
+    }
+
+    public void deleteById(Long folderId){
+        foldersDocumentRepository.deleteById(folderId);
     }
 
 

--- a/src/main/java/com/Kkrap/Service/FoldersDocument/FoldersDocumentService.java
+++ b/src/main/java/com/Kkrap/Service/FoldersDocument/FoldersDocumentService.java
@@ -41,10 +41,10 @@ public class FoldersDocumentService {
                 .collect(Collectors.toList());
     }
 
-    public List<FoldersDocument> getTop10LikesCountLastWeek() {
-        List<FoldersDocument> docs = foldersDocumentRepository.findTop10ByCreateTimeInLastWeekOrderByLikesCountDesc();
+    public List<FoldersDocument> getTop10ScrapCountLastWeek() {
+        List<FoldersDocument> docs = foldersDocumentRepository.findTop10ByCreateTimeInLastWeekOrderByScrapCountDesc();
         return docs.stream()
-                .sorted(Comparator.comparingLong(FoldersDocument::getLikesCount).reversed())
+                .sorted(Comparator.comparingLong(FoldersDocument::getScrapCount).reversed())
                 .limit(10)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/Kkrap/Service/Follows/FollowsManagerService.java
+++ b/src/main/java/com/Kkrap/Service/Follows/FollowsManagerService.java
@@ -1,0 +1,51 @@
+package com.Kkrap.Service.Follows;
+
+import com.Kkrap.Entity.Follows;
+import com.Kkrap.Entity.Users;
+import com.Kkrap.ResponseDto.FollowsResponse;
+import com.Kkrap.ResponseDto.MessageResponse;
+import com.Kkrap.ResponseDto.UsersProfileResponse;
+import com.Kkrap.Service.Users.UsersService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class FollowsManagerService {
+
+    private final FollowsService followsService;
+    private final UsersService usersService;
+
+    public FollowsManagerService(FollowsService followsService, UsersService usersService){
+        this.followsService = followsService;
+        this.usersService = usersService;
+    }
+
+    public ResponseEntity<FollowsResponse> followUser(Long followerId, Long followingId){
+        Users follower = usersService.findById(followerId);
+        Users following = usersService.findById(followingId);
+        return ResponseEntity.ok(FollowsResponse.of(followsService.save(follower, following)));
+    }
+
+    public ResponseEntity<FollowsResponse> unFollowUser(Long followerId, Long followingId){
+        Users follower = usersService.findById(followerId);
+        Users following = usersService.findById(followingId);
+
+        Follows response = followsService.delete(follower, following);
+        return ResponseEntity.ok(FollowsResponse.of(response));
+    }
+
+    //팔로우 기능 닉네임 조회
+    public ResponseEntity<List<UsersProfileResponse>> findUsersByNicknameContains(String nickname) {
+        List<Users> users = usersService.findByNicknameContaining(nickname);
+        List<UsersProfileResponse> responseList = users.stream()
+                .map(UsersProfileResponse::from)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(responseList);
+    }
+
+
+
+}

--- a/src/main/java/com/Kkrap/Service/Follows/FollowsService.java
+++ b/src/main/java/com/Kkrap/Service/Follows/FollowsService.java
@@ -1,0 +1,32 @@
+package com.Kkrap.Service.Follows;
+
+import com.Kkrap.Entity.Follows;
+import com.Kkrap.Entity.Users;
+import com.Kkrap.Exception.AlreadyFollowingException;
+import com.Kkrap.Exception.FollowNotFoundException;
+import com.Kkrap.Repository.FollowsRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class FollowsService {
+    private  final FollowsRepository followsRepository;
+
+    public FollowsService(FollowsRepository followsRepository){
+        this.followsRepository = followsRepository;
+    }
+
+    public Follows save(Users follower, Users following){
+        if (followsRepository.existsByFollowerAndFollowingId(follower, following.getUserId())) {
+            throw new AlreadyFollowingException("이미 팔로우 중입니다.");
+        }
+        return followsRepository.save(Follows.of(follower, following));
+    }
+
+    public Follows delete(Users follower, Users following){
+        Follows follows = followsRepository.findByFollowerAndFollowingId(follower, following.getUserId())
+                .orElseThrow(() -> new FollowNotFoundException("팔로우 관계가 존재하지 않습니다."));
+        followsRepository.delete(follows);
+        return follows;
+    }
+
+}

--- a/src/main/java/com/Kkrap/Service/FollowsFoldersPermission/FoldersPermissionsManagerService.java
+++ b/src/main/java/com/Kkrap/Service/FollowsFoldersPermission/FoldersPermissionsManagerService.java
@@ -1,0 +1,56 @@
+package com.Kkrap.Service.FollowsFoldersPermission;
+
+
+import com.Kkrap.Entity.Folders;
+import com.Kkrap.Entity.FoldersPermissions;
+import com.Kkrap.Entity.Users;
+import com.Kkrap.RequestDTO.FoldersPermissionsCreateRequest;
+import com.Kkrap.RequestDTO.FoldersPermissionsDeleteRequest;
+import com.Kkrap.Service.FolderLink.FoldersService;
+import com.Kkrap.Service.Users.UsersService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+@Service
+public class FoldersPermissionsManagerService {
+
+    private final UsersService usersService;
+
+    private final FoldersPermissionsService foldersPermissionsService;
+
+    private final FoldersService foldersService;
+
+    public FoldersPermissionsManagerService(UsersService usersService, FoldersPermissionsService foldersPermissionsService,
+                                            FoldersService foldersService){
+        this.usersService = usersService;
+        this.foldersPermissionsService = foldersPermissionsService;
+        this.foldersService = foldersService;
+    }
+
+    public ResponseEntity<FoldersPermissionsCreateRequest> shareFolderWithUsers(Long userId, FoldersPermissionsCreateRequest request) {
+        Users owner = usersService.findById(userId);
+        Folders folder = foldersService.findById(request.getFolderId());
+        foldersService.isOwnedByService(folder, userId);
+
+        for (Long invitedUserId : request.getInvitedUserIds()) {
+            Users invitedUser = usersService.findById(invitedUserId);
+
+            boolean exists = foldersPermissionsService.existsByFolderAndInvitedUserId(folder, invitedUserId);
+            if (exists) continue;
+            foldersPermissionsService.save(owner, folder, invitedUser);
+        }
+        return ResponseEntity.ok(request);
+    }
+
+    public ResponseEntity<FoldersPermissionsDeleteRequest> revokeFolderPermission(Long ownerId, FoldersPermissionsDeleteRequest request) {
+        usersService.findById(ownerId);
+        Folders folder = foldersService.findById(request.getFolderId());
+        foldersService.isOwnedByService(folder, ownerId);
+
+        // 삭제할 권한 찾기
+        FoldersPermissions permission = foldersPermissionsService.findByFolderAndInvitedUserId(folder, request.getInvitedUserId());
+        foldersPermissionsService.delete(permission);
+        return ResponseEntity.ok(request);
+
+    }
+}

--- a/src/main/java/com/Kkrap/Service/FollowsFoldersPermission/FoldersPermissionsService.java
+++ b/src/main/java/com/Kkrap/Service/FollowsFoldersPermission/FoldersPermissionsService.java
@@ -7,6 +7,8 @@ import com.Kkrap.Exception.FoldersPermissionNotFoundException;
 import com.Kkrap.Repository.FoldersPermissionsRepository;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 public class FoldersPermissionsService {
 
@@ -33,6 +35,10 @@ public class FoldersPermissionsService {
                 .findByFolderAndInvitedUserId(folders, invitedUserId)
                 .orElseThrow(() -> FoldersPermissionNotFoundException.from("공유 권한이 존재하지 않습니다."));
         return permission;
+    }
+
+    public List<FoldersPermissions> findByInvitedUserId(Long invitedUserId) {
+        return foldersPermissionsRepository.findByInvitedUserId(invitedUserId);
     }
 
 }

--- a/src/main/java/com/Kkrap/Service/FollowsFoldersPermission/FoldersPermissionsService.java
+++ b/src/main/java/com/Kkrap/Service/FollowsFoldersPermission/FoldersPermissionsService.java
@@ -1,0 +1,38 @@
+package com.Kkrap.Service.FollowsFoldersPermission;
+
+import com.Kkrap.Entity.Folders;
+import com.Kkrap.Entity.FoldersPermissions;
+import com.Kkrap.Entity.Users;
+import com.Kkrap.Exception.FoldersPermissionNotFoundException;
+import com.Kkrap.Repository.FoldersPermissionsRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class FoldersPermissionsService {
+
+    private final FoldersPermissionsRepository foldersPermissionsRepository;
+
+    public FoldersPermissionsService(FoldersPermissionsRepository foldersPermissionsRepository){
+        this.foldersPermissionsRepository = foldersPermissionsRepository;
+    }
+
+    public boolean existsByFolderAndInvitedUserId(Folders folder, Long invitedUserId){
+        return foldersPermissionsRepository.existsByFolderAndInvitedUserId(folder, invitedUserId);
+    }
+
+    public FoldersPermissions save(Users owner, Folders folders, Users invitedUser){
+        return foldersPermissionsRepository.save(FoldersPermissions.of(owner, folders, invitedUser));
+    }
+
+    public void delete(FoldersPermissions permission){
+        foldersPermissionsRepository.delete(permission);
+    }
+
+    public FoldersPermissions findByFolderAndInvitedUserId(Folders folders, Long invitedUserId){
+        FoldersPermissions permission = foldersPermissionsRepository
+                .findByFolderAndInvitedUserId(folders, invitedUserId)
+                .orElseThrow(() -> FoldersPermissionNotFoundException.from("공유 권한이 존재하지 않습니다."));
+        return permission;
+    }
+
+}

--- a/src/main/java/com/Kkrap/Service/FollowsFoldersPermission/FollowsManagerService.java
+++ b/src/main/java/com/Kkrap/Service/FollowsFoldersPermission/FollowsManagerService.java
@@ -2,8 +2,8 @@ package com.Kkrap.Service.FollowsFoldersPermission;
 
 import com.Kkrap.Entity.Follows;
 import com.Kkrap.Entity.Users;
-import com.Kkrap.ResponseDto.FollowsResponse;
-import com.Kkrap.ResponseDto.UsersProfileResponse;
+import com.Kkrap.ResponseDTO.FollowsResponse;
+import com.Kkrap.ResponseDTO.UsersProfileResponse;
 import com.Kkrap.Service.Users.UsersService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/Kkrap/Service/FollowsFoldersPermission/FollowsManagerService.java
+++ b/src/main/java/com/Kkrap/Service/FollowsFoldersPermission/FollowsManagerService.java
@@ -1,9 +1,8 @@
-package com.Kkrap.Service.Follows;
+package com.Kkrap.Service.FollowsFoldersPermission;
 
 import com.Kkrap.Entity.Follows;
 import com.Kkrap.Entity.Users;
 import com.Kkrap.ResponseDto.FollowsResponse;
-import com.Kkrap.ResponseDto.MessageResponse;
 import com.Kkrap.ResponseDto.UsersProfileResponse;
 import com.Kkrap.Service.Users.UsersService;
 import org.springframework.http.ResponseEntity;
@@ -22,6 +21,16 @@ public class FollowsManagerService {
         this.followsService = followsService;
         this.usersService = usersService;
     }
+
+    public ResponseEntity<List<FollowsResponse>> getFollowingList(Long followerId){
+        Users users = usersService.findById(followerId);
+        List<Follows> response = followsService.findByFollower(users);
+        List<FollowsResponse> responseList = response.stream()
+                .map(FollowsResponse::of)
+                .toList();
+        return ResponseEntity.ok(responseList);
+    }
+
 
     public ResponseEntity<FollowsResponse> followUser(Long followerId, Long followingId){
         Users follower = usersService.findById(followerId);

--- a/src/main/java/com/Kkrap/Service/FollowsFoldersPermission/FollowsService.java
+++ b/src/main/java/com/Kkrap/Service/FollowsFoldersPermission/FollowsService.java
@@ -1,4 +1,4 @@
-package com.Kkrap.Service.Follows;
+package com.Kkrap.Service.FollowsFoldersPermission;
 
 import com.Kkrap.Entity.Follows;
 import com.Kkrap.Entity.Users;
@@ -6,6 +6,8 @@ import com.Kkrap.Exception.AlreadyFollowingException;
 import com.Kkrap.Exception.FollowNotFoundException;
 import com.Kkrap.Repository.FollowsRepository;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 public class FollowsService {
@@ -27,6 +29,10 @@ public class FollowsService {
                 .orElseThrow(() -> new FollowNotFoundException("팔로우 관계가 존재하지 않습니다."));
         followsRepository.delete(follows);
         return follows;
+    }
+
+    public List<Follows> findByFollower(Users follower){
+        return followsRepository.findByFollower(follower);
     }
 
 }

--- a/src/main/java/com/Kkrap/Service/LoginUserHandler.java
+++ b/src/main/java/com/Kkrap/Service/LoginUserHandler.java
@@ -3,7 +3,7 @@ package com.Kkrap.Service;
 import com.Kkrap.Entity.Users;
 import com.Kkrap.RequestDTO.FoldersCreateRequest;
 import com.Kkrap.RequestDTO.UsersCreateRequest;
-import com.Kkrap.ResponseDto.UsersProfileResponse;
+import com.Kkrap.ResponseDTO.UsersProfileResponse;
 import com.Kkrap.Service.FolderLink.FoldersService;
 import com.Kkrap.Service.Users.UsersService;
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/Kkrap/Service/Users/UsersManagerService.java
+++ b/src/main/java/com/Kkrap/Service/Users/UsersManagerService.java
@@ -2,15 +2,12 @@ package com.Kkrap.Service.Users;
 
 
 import com.Kkrap.Entity.Users;
-import com.Kkrap.ResponseDto.MessageResponse;
-import com.Kkrap.ResponseDto.UsersProfileResponse;
+import com.Kkrap.ResponseDTO.MessageResponse;
+import com.Kkrap.ResponseDTO.UsersProfileResponse;
 import com.Kkrap.Util.FileStorageUtil;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 public class UsersManagerService {

--- a/src/main/java/com/Kkrap/Service/Users/UsersManagerService.java
+++ b/src/main/java/com/Kkrap/Service/Users/UsersManagerService.java
@@ -1,21 +1,33 @@
 package com.Kkrap.Service.Users;
 
 
+import com.Kkrap.Entity.Folders;
 import com.Kkrap.Entity.Users;
 import com.Kkrap.ResponseDTO.MessageResponse;
 import com.Kkrap.ResponseDTO.UsersProfileResponse;
+import com.Kkrap.Service.FolderLink.FoldersService;
+import com.Kkrap.Service.FoldersDocument.FoldersDocumentService;
 import com.Kkrap.Util.FileStorageUtil;
+import jakarta.transaction.Transactional;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @Service
 public class UsersManagerService {
 
     private final UsersService usersService;
 
-    public UsersManagerService(UsersService usersService){
+    private final FoldersService foldersService;
+
+    private final FoldersDocumentService foldersDocumentService;
+
+    public UsersManagerService(UsersService usersService, FoldersService foldersService, FoldersDocumentService foldersDocumentService){
         this.usersService = usersService;
+        this.foldersService = foldersService;
+        this.foldersDocumentService = foldersDocumentService;
     }
 
     public ResponseEntity<UsersProfileResponse> getUserProfile(Long userId){
@@ -23,11 +35,17 @@ public class UsersManagerService {
         return ResponseEntity.ok(UsersProfileResponse.of(users.getUserId(),users.getEmail(), users.getNickname(), users.getProfile(), users.getKakaoId(), users.getBio()));
     }
 
+    @Transactional
     public ResponseEntity<UsersProfileResponse> updateUserProfile(Long userId, String newNickname, String bio){
         Users users = usersService.findById(userId);
         users.setNickname(newNickname);
         users.setBio(bio);
         usersService.save(users);
+
+        //색인 업데이트
+        List<Folders> userFolders = foldersService.findByUserIdAndVisibleTrue(userId);
+        foldersDocumentService.updateUserInfoInFolderDocuments(users, userFolders);
+
         return ResponseEntity.ok(UsersProfileResponse.from(users));
     }
 

--- a/src/main/java/com/Kkrap/Service/Users/UsersManagerService.java
+++ b/src/main/java/com/Kkrap/Service/Users/UsersManagerService.java
@@ -9,6 +9,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 public class UsersManagerService {
 
@@ -48,6 +51,8 @@ public class UsersManagerService {
         usersService.findByNickname(nickname);
         return ResponseEntity.ok(MessageResponse.of(200, "사용 가능한 닉네임입니다."));
     }
+
+
 
 
 }

--- a/src/main/java/com/Kkrap/Service/Users/UsersService.java
+++ b/src/main/java/com/Kkrap/Service/Users/UsersService.java
@@ -7,6 +7,7 @@ import com.Kkrap.Repository.UsersRepository;
 import com.Kkrap.RequestDTO.UsersCreateRequest;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Optional;
 
 
@@ -44,6 +45,10 @@ public class UsersService {
 
     public Optional<Users> findByKakaoId(Long id) {
         return usersRepository.findByKaKaoId(id);
+    }
+
+    public List<Users> findByNicknameContaining(String nickname){
+        return usersRepository.findByNicknameContaining(nickname);
     }
 
 }


### PR DESCRIPTION
저번에 요청하였던 조회수 기능에 대한 아키텍처 자료 올립니다.
<img width="1091" alt="image" src="https://github.com/user-attachments/assets/5d41071e-0e49-4c67-bf79-68745f5851b0" />

# 기능 변경 사항
### elasticsearch
- elasticsearch 환경 설정 진행하였고 EC2 docker-compose에 올려두었습니다.
- elastchsearch 검색바를 통해 폴더를 조회하는 기능을 구현
아키텍처는 다음과 같습니다.
<img width="943" alt="image" src="https://github.com/user-attachments/assets/3c99f5e6-240d-4ce1-9708-5019d195be73" />

- elasticsearch 조회수순, 스크랩순 일주일내 Top10 조회하는 기능을 구현
아키텍처는 다음과 같습니다.
<img width="937" alt="image" src="https://github.com/user-attachments/assets/a73dd7f4-d5d6-437c-b685-15b1131cd665" />

### 폴더(folders)
- 폴더 저장할 때 folders 저장 카프카 이용해서 색인 업데이트
아키텍처는 다음과 같습니다
<img width="943" alt="image" src="https://github.com/user-attachments/assets/d78423d4-12a7-487b-85e5-ecde2bb88cf7" />
- 폴더 삭제 수정, 사용자 정보 변경 후 색인 업데이트 기능 추가
- (상대방이 나의 모든 폴더 및 썸네일 4개 조회, 자신의 모든 폴더 및 썸네일 4개 조회, 상대방이 나의 하나의 폴더 및 모든 링크 조회, 자신의 하나 폴더 및 모든 링크 조회) ReponseDTO 변경, 색인 업데이트 share 추가, folders 공유됨 확인 컬럼 share 추가

### 팔로우(친구)
- 팔로우 기능 구현(follws 테이블 추가, 팔로우 추가, 팔로우 삭제, 닉네임을 통해 검색 기능 구현[검색 값의 스트링에 포함된 모든 유저 조회])
- 권한 부여 추가 및 삭제 기능 구현

### 무한 스크롤 
- 무한 스크롤 아키텍처는 다음과 같이 생각하고 있습니다.
<img width="934" alt="image" src="https://github.com/user-attachments/assets/df88ee76-97bf-455e-9154-5de884bd44bf" />


# 최종 아키텍처 수정본입니다
<img width="987" alt="image" src="https://github.com/user-attachments/assets/e60c7a45-f2ae-4b27-bb40-3fac6c08b9d4" />


### 개선 및 생각해봐야될 점
- 팔로우에서 사용자를 찾기 위해 닉네임을 검색하게 되는데 현재 LIKE SQL문으로 값을 가져옵니다. 이것 보다 좀 더 성능을 빠르게 할 수 있는 방법을 찾아보고자 합니다
- 저번에 회의 때 이야기해주셨던 마스터-슬레이브 구조에 대해서 한 번 찾아봐라고 해주셨는데 찾아보았습니다. 저번에 제가 elasticsearch를 쓰기 위해 읽기 전용 DB가 필요하다고 하였는데 이 부분이 조금 잘못 이해하고 있었습니다. DB가 필요한 게 아니라 색인이라는 게 필요합니다 결국 folders 정보, 유저 정보를 같이 합쳐서 foldersDocument 이름으로 색인을 만들어서 elasticsearch가 검색할 때 이 색인을 사용하게 됩니다 즉, folders만 정보만 필요한 게 아니라 유저 정보 + folders 정보를 같이 저장하고 색인을 해야하기에 읽기 전용 DB가 필요없어졌다고 생각했는데 folders를 많이 조회하게 되는데 여기서 folders를 마스터-슬레이브 구조로 가져가서 folders 캐싱 느낌으로 진행하면 좋을 것 같다고 생각했습니다 이 부분은 좀 마지막 쯤에 성능 개선할 때 하면 좋아보입니다.