### PR TITLE
feat: AuthService 테스트 추가

### DIFF
--- a/src/test/java/com/Kkrap/Auth/AuthServiceTest.java
+++ b/src/test/java/com/Kkrap/Auth/AuthServiceTest.java
@@ -1,0 +1,63 @@
+package com.Kkrap.Auth;
+
+import autoparams.AutoSource;
+import com.Kkrap.Repository.FoldersRepository;
+import com.Kkrap.Repository.UsersRepository;
+import com.Kkrap.RequestDTO.KaKaoTokenRequest;
+import com.Kkrap.ResponseDto.UsersProfileResponse;
+import com.Kkrap.Service.AuthService;
+import com.Kkrap.Service.LoginUserPort;
+import com.Kkrap.Service.SocialLogin.ClientProvider;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class AuthServiceTest {
+
+     @InjectMocks AuthService authService;
+     @Mock private UsersRepository usersRepository;
+     @Mock private FoldersRepository foldersRepository;
+     @Mock private ClientProvider clientProvider;
+     @Mock private LoginUserPort loginUserPort;
+
+     @AutoSource
+     @ParameterizedTest
+     @DisplayName("카카오 콜백 응답을 받았을 경우, 사용자 프로필 데이터 폼을 반환한다.")
+     void callbackResponse(KaKaoTokenRequest request, UsersProfileResponse response) {
+         // given
+         Map<String, Object> mockClientResponse = new HashMap<>();
+         Map<String, Object> kakaoAccount = new HashMap<>();
+         Map<String, Object> profile = new HashMap<>();
+         kakaoAccount.put("id", 123456789L);
+         kakaoAccount.put("email", "test@example.com");
+         profile.put("nickname", "홍길동");
+         profile.put("profile_image_url", UUID.randomUUID().toString());
+         mockClientResponse.put("kakao_account", kakaoAccount);
+         kakaoAccount.put("profile", profile);
+
+         request.setAccesstoken(UUID.randomUUID().toString());
+         given(clientProvider.getClient(request.getAccesstoken())).willReturn(mockClientResponse);
+
+         //when
+         Map<String, Object> result = clientProvider.getClient(request.getAccesstoken());
+
+          //then
+         Assertions.assertThat(result).isNotNull();
+         Assertions.assertThat(result.get("kakao_account")).isNotNull();
+     }
+
+}


### PR DESCRIPTION
AuthService 클래스 테스트 코드를 추가하였습니다. API 에서의 추가적인 테스트 케이스는 발견되지 않아, Service 쪽으로 넘어왔습니다.
Mockito를 통해서 테스트 영역을 세부적으로 조절하여 테스트하였습니다. 테스트한 기능은 아래와 같습니다.

- isAccessToken 메서드 유효한 동작 검증
- getUsersProfile 메서드 유효한 동작 검증

##### 목 처리된 클래스

- UsersRepository usersRepository;
 - FoldersRepository foldersRepository;
 - ClientProvider clientProvider;

