### PR TITLE
feat : 유저 정보에 폴더 정보 추가, 폴더 삭제 시 모든 링크가 삭제 안 되게 변경, 링크 저장시 '//' '///'을 '/'로 처리해서 저장 

### DIFF
--- a/src/main/java/com/Kkrap/Controller/UsersController.java
+++ b/src/main/java/com/Kkrap/Controller/UsersController.java
@@ -1,6 +1,7 @@
 package com.Kkrap.Controller;
 
 import com.Kkrap.RequestDTO.ProfileUpdateRequest;
+import com.Kkrap.ResponseDTO.FoldersUserProfileResponse;
 import com.Kkrap.ResponseDTO.MessageResponse;
 import com.Kkrap.ResponseDTO.UsersProfileResponse;
 import com.Kkrap.Service.Users.UsersManagerService;
@@ -31,6 +32,18 @@ public class UsersController {
     {
         return usersManagerService.getUserProfile(userId);
     }
+
+    @GetMapping("folders/{userId}")
+    @Operation(summary = "내 폴더 전용 사용자 프로필 조회", description = "내 폴더 전용 사용자의 프로필 조회")
+    @ResponseBody
+    public ResponseEntity<FoldersUserProfileResponse> getFoldersUserProfile(
+            @Parameter(name = "userId", description = "수정할 사용자 ID", required = true, example = "1")
+            @PathVariable("userId") Long userId)
+    {
+        return usersManagerService.getFoldersUserProfile(userId);
+    }
+
+
 
     //닉네임 변경
     @PatchMapping("/{userId}/profile")

--- a/src/main/java/com/Kkrap/Repository/FoldersRepository.java
+++ b/src/main/java/com/Kkrap/Repository/FoldersRepository.java
@@ -1,6 +1,7 @@
 package com.Kkrap.Repository;
 
 import com.Kkrap.Entity.Folders;
+import com.Kkrap.Entity.Users;
 import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -9,6 +10,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface FoldersRepository extends JpaRepository<Folders, Long> {
@@ -21,5 +23,9 @@ public interface FoldersRepository extends JpaRepository<Folders, Long> {
     void incrementViewCountById(@Param("folderId") Long folderId);
 
     List<Folders> findByUserUserIdAndVisibleTrue(Long userId);
+
+
+    @Query("SELECT COALESCE(SUM(f.viewCount), 0) FROM Folders f WHERE f.user = :user")
+    Long sumViewCountByUser(@Param("user") Users user);
 
 }

--- a/src/main/java/com/Kkrap/Repository/FollowsRepository.java
+++ b/src/main/java/com/Kkrap/Repository/FollowsRepository.java
@@ -15,4 +15,6 @@ public interface FollowsRepository extends JpaRepository<Follows, Long> {
     Optional<Follows> findByFollowerAndFollowingId(Users follower, Long followingId);
 
     List<Follows> findByFollower(Users follower);
+
+    Long countByFollowingId(Long followingId);
 }

--- a/src/main/java/com/Kkrap/ResponseDTO/FoldersUserProfileResponse.java
+++ b/src/main/java/com/Kkrap/ResponseDTO/FoldersUserProfileResponse.java
@@ -1,0 +1,34 @@
+package com.Kkrap.ResponseDTO;
+
+import com.Kkrap.Entity.Users;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class FoldersUserProfileResponse {
+    private Long userId;
+    private String nickname;
+    private String profile;
+    private String bio;
+
+    private Long totalViewCount;
+    private Long followingCount;
+
+    public static FoldersUserProfileResponse of(
+            Users user,
+            Long totalViewCount,
+            Long followingCount
+    ) {
+        return new FoldersUserProfileResponse(
+                user.getUserId(),
+                user.getNickname(),
+                user.getProfile(),
+                user.getBio(),
+                totalViewCount,
+                followingCount
+                );
+    }
+}

--- a/src/main/java/com/Kkrap/Service/FolderLink/FoldersManagerService.java
+++ b/src/main/java/com/Kkrap/Service/FolderLink/FoldersManagerService.java
@@ -255,11 +255,6 @@ public class FoldersManagerService {
         Folders folders = foldersService.findById(folderId);
         List<FoldersLinks> folderLinksList = foldersLinksService.findByFolders(folders);
 
-        for (FoldersLinks folderLink : folderLinksList) {
-            Links link = folderLink.getLinks();
-            linksService.deleteById(link.getLinkId());
-        }
-
         // FoldersLinks 테이블에서 해당 folderId를 가진 데이터 삭제
         foldersLinksService.deleteAll(folderLinksList);
 

--- a/src/main/java/com/Kkrap/Service/FolderLink/FoldersService.java
+++ b/src/main/java/com/Kkrap/Service/FolderLink/FoldersService.java
@@ -71,6 +71,10 @@ public class FoldersService {
         }
     }
 
+    public Long sumViewCountByUser(Users user) {
+        return foldersRepository.sumViewCountByUser(user);
+    }
+
 
 
 

--- a/src/main/java/com/Kkrap/Service/FolderLink/LinksManagerService.java
+++ b/src/main/java/com/Kkrap/Service/FolderLink/LinksManagerService.java
@@ -42,7 +42,9 @@ public class LinksManagerService {
 
         //모든 링크 폴더에도 추가를 해주어야함
         //만약 foldersId랑 deafultFoldersId랑 같으면 삽입이 필요없고 다르면 넣어야됨
-        if (linksCreateRequest.getFoldersId() != linksCreateRequest.getDefaultFoldersId()){ foldersLinksService.save(FoldersLinks.of(defaultfolders, links, userId)); }
+        if (linksCreateRequest.getFoldersId() != linksCreateRequest.getDefaultFoldersId()){
+            foldersLinksService.save(FoldersLinks.of(defaultfolders, links, userId));
+        }
         return ResponseEntity.ok(LinksCreateResponse.of(links, linksCreateRequest.getDefaultFoldersId(), linksCreateRequest.getFoldersId()));
     }
 

--- a/src/main/java/com/Kkrap/Service/FollowsFoldersPermission/FollowsService.java
+++ b/src/main/java/com/Kkrap/Service/FollowsFoldersPermission/FollowsService.java
@@ -35,4 +35,8 @@ public class FollowsService {
         return followsRepository.findByFollower(follower);
     }
 
+    public Long countFollower(Long userId) {
+        return followsRepository.countByFollowingId(userId);
+    }
+
 }

--- a/src/main/java/com/Kkrap/Service/Users/UsersManagerService.java
+++ b/src/main/java/com/Kkrap/Service/Users/UsersManagerService.java
@@ -3,10 +3,12 @@ package com.Kkrap.Service.Users;
 
 import com.Kkrap.Entity.Folders;
 import com.Kkrap.Entity.Users;
+import com.Kkrap.ResponseDTO.FoldersUserProfileResponse;
 import com.Kkrap.ResponseDTO.MessageResponse;
 import com.Kkrap.ResponseDTO.UsersProfileResponse;
 import com.Kkrap.Service.FolderLink.FoldersService;
 import com.Kkrap.Service.FoldersDocument.FoldersDocumentService;
+import com.Kkrap.Service.FollowsFoldersPermission.FollowsService;
 import com.Kkrap.Util.FileStorageUtil;
 import jakarta.transaction.Transactional;
 import org.springframework.http.ResponseEntity;
@@ -24,16 +26,31 @@ public class UsersManagerService {
 
     private final FoldersDocumentService foldersDocumentService;
 
-    public UsersManagerService(UsersService usersService, FoldersService foldersService, FoldersDocumentService foldersDocumentService){
+    private final FollowsService followsService;
+
+    public UsersManagerService(UsersService usersService, FoldersService foldersService, FoldersDocumentService foldersDocumentService,
+                               FollowsService followsService){
         this.usersService = usersService;
         this.foldersService = foldersService;
         this.foldersDocumentService = foldersDocumentService;
+        this.followsService = followsService;
     }
 
     public ResponseEntity<UsersProfileResponse> getUserProfile(Long userId){
         Users users = usersService.findById(userId);
         return ResponseEntity.ok(UsersProfileResponse.of(users.getUserId(),users.getEmail(), users.getNickname(), users.getProfile(), users.getKakaoId(), users.getBio()));
     }
+
+    public ResponseEntity<FoldersUserProfileResponse> getFoldersUserProfile(Long userId){
+        Users user = usersService.findById(userId);
+
+        Long totalViewCount = foldersService.sumViewCountByUser(user);
+        Long followingCount = followsService.countFollower(user.getUserId());
+
+        return ResponseEntity.ok(
+                FoldersUserProfileResponse.of(user, totalViewCount, followingCount)
+        );
+ }
 
     @Transactional
     public ResponseEntity<UsersProfileResponse> updateUserProfile(Long userId, String newNickname, String bio){

--- a/src/main/java/com/Kkrap/Util/LinkMetadataExtractor.java
+++ b/src/main/java/com/Kkrap/Util/LinkMetadataExtractor.java
@@ -76,10 +76,37 @@ public class LinkMetadataExtractor {
         Metadata meta = extract(url);
 
         String linkName = (meta.title != null && !meta.title.isBlank()) ? meta.title : null;
-        String thumbnailUrl = (meta.thumbnailUrl != null && !meta.thumbnailUrl.isBlank()) ? meta.thumbnailUrl : null;
+        String thumbnailUrl = (meta.thumbnailUrl != null && !meta.thumbnailUrl.isBlank())
+                ? normalizeUrlSlashes(meta.thumbnailUrl)
+                : null;
         String faviconUrl = (meta.faviconUrl != null && !meta.faviconUrl.isBlank()) ? meta.faviconUrl : null;
 
         return Links.of(url, linkName, thumbnailUrl, faviconUrl);
+    }
+
+    public static String normalizeUrlSlashes(String url) {
+        if (url == null) return null;
+
+        // 프로토콜 구분
+        int protocolIndex = url.indexOf("://");
+        if (protocolIndex == -1) {
+            // 프로토콜 없음 → 전체 처리
+            return url.replaceAll("/{2,}", "/");
+        }
+
+        String protocolPart = url.substring(0, protocolIndex + 3);
+        String rest = url.substring(protocolIndex + 3);
+
+        int firstSlash = rest.indexOf('/');
+        if (firstSlash == -1) {
+            // 슬래시가 없음 → 경로가 없음
+            return protocolPart + rest;
+        }
+        String host = rest.substring(0, firstSlash);        // 호스트 이름
+        String path = rest.substring(firstSlash);           // 경로 전체
+        // 경로에서 슬래시 중복 제거
+        String normalizedPath = path.replaceAll("/{2,}", "/");
+        return protocolPart + host + normalizedPath;
     }
 
 }


### PR DESCRIPTION
변경 사항
- 보관함 페이지에서 조회수, 스크랩수, 팔로워수가 필요하기에 유저정보와 합친 API를 하나 더 만들었습니다.
- 폴더 삭제시 모든 링크 폴더에 있는 것까지 삭제가 되어서 삭제되지 않게 변경하였습니다.
- 링크 저장시 '///', '//'이게 썸네일로 있을 때 사진이 열리지 않는 문제가 있어 모두 '/'으로 처리하게 만들었습니다.