### PR TITLE
test: 빈 문자열들이 들어오면 valid 어노테이션으로 검증하는 테스트 케이스 구성

### DIFF
--- a/src/main/java/com/Kkrap/RequestDTO/FoldersCreateRequest.java
+++ b/src/main/java/com/Kkrap/RequestDTO/FoldersCreateRequest.java
@@ -1,5 +1,6 @@
 package com.Kkrap.RequestDTO;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,8 +12,10 @@ import lombok.Setter;
 @AllArgsConstructor
 public class FoldersCreateRequest {
 
+    @NotNull
     private String folderName;
 
+    @NotNull
     private String folderDescription;
 
     private boolean visible;

--- a/src/test/java/com/Kkrap/endpoint/FoldersEndpointTest.java
+++ b/src/test/java/com/Kkrap/endpoint/FoldersEndpointTest.java
@@ -1,0 +1,52 @@
+package com.Kkrap.endpoint;
+
+import com.Kkrap.Controller.FoldersController;
+import com.Kkrap.RequestDTO.FoldersCreateRequest;
+import com.Kkrap.Service.FolderLink.FoldersManagerService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
+@WebMvcTest(FoldersController.class)
+public class FoldersEndpointTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @MockBean private FoldersManagerService foldersManagerService;
+
+    @Test
+    @DisplayName("빈 이름을 전달하면, IllegalArgumentException 에러가 발생한다.")
+    void nullPointName( ) {
+        FoldersCreateRequest request = FoldersCreateRequest.of("", "설명", true, true);
+        Long userId = 12345L;
+
+        Assertions.assertThrows(IllegalArgumentException.class ,() -> {
+            mockMvc.perform(post("/folders/users/{userId}/folders"+userId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            );
+        });
+    }
+
+    @Test
+    @DisplayName("빈 설명을 전달하면, IllegalArgumentException 에러가 발생한다.")
+    void nullPointDescription( ) {
+        FoldersCreateRequest request = FoldersCreateRequest.of("제목", "", true, true);
+        Long userId = 12345L;
+
+        Assertions.assertThrows(IllegalArgumentException.class ,() -> {
+            mockMvc.perform(post("/folders/users/{userId}/folders"+userId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            );
+        });
+    }
+}


### PR DESCRIPTION
consumer 에서 테스트를 진행하다, 팀원과 논의를 진행하여 나온 결정은 아래와 같습니다.

*producer 전 로직에서 nullcheck 미리 처리해버리자.*

controller에서 빈 문자열들이 검증되도록 @valid 어노테이션을 추가하였습니다.

해당 pr은 테스트 케이스 입니다.

<img width="629" height="115" alt="image" src="https://github.com/user-attachments/assets/d09a9d13-7c99-48f0-9270-a183a3a8c3a4" />


